### PR TITLE
Update pyactiveresource to avoid unicode encoding errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name=NAME,
       scripts=['scripts/shopify_api.py'],
       license='MIT License',
       install_requires=[
-          'pyactiveresource>=1.0.0',
+          'pyactiveresource>=1.0.2',
           'python-dateutil<2.0', # >= 2.0 is for python>=3.0
           'PyYAML',
       ],


### PR DESCRIPTION
PyActiveResource 1.0.2 is out, and this fixes the errors referenced here: https://groups.google.com/forum/?hl=en&fromgroups=#!topic/shopify-app-discuss/T5gee1A_2lE and https://github.com/Shopify/shopify_python_api/blob/master/shopify/base.py#L150
