### PR TITLE
Allow article lookup by ID without the blog_id requirement

### DIFF
--- a/shopify/resources.py
+++ b/shopify/resources.py
@@ -152,6 +152,11 @@ class Blog(ShopifyResource, mixins.Metafields, mixins.Events):
 class Article(ShopifyResource, mixins.Metafields, mixins.Events):
     _prefix_source = "/admin/blogs/$blog_id/"
 
+    @classmethod
+    def _prefix(cls, options={}):
+        blog_id = options.get("blog_id")
+        return "/admin/" if blog_id is None else "/admin/blogs/%s" % (blog_id)
+
     def comments(self):
         return Comment.find(article_id=self.id)
 


### PR DESCRIPTION
As with variants, blog articles can be retrieved without needing to specify a blog_id. For example...

**This ...**

```
/admin/articles/8522335.json
```

**... is the same as this ...**

```
/admin/blogs/2907647/articles/8522335.json
```

Simply duplicated the solution already implemented for variants. Added _prefix classmethod to Article resource handling blog_id presence or absence same as the Variant resource does for product_id.
