### PR TITLE
Fixes issue #45

### DIFF
--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -7,7 +7,7 @@ from smart_collection import SmartCollection
 class Product(ShopifyResource, mixins.Metafields, mixins.Events):
 
     def price_range(self):
-        prices = [variant.price for variant in self.variants]
+        prices = [float(variant.price) for variant in self.variants]
         f = "%0.2f"
         min_price = min(prices)
         max_price = max(prices)


### PR DESCRIPTION
Fixes a bug where a type error was caused on the return statements for the price_range() function.  variant.price is not a float, it's a unicode string.
