### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ these steps:
     and you'll get your permanent access token back in the response.
 
     There is a method to make the request and get the token for you. Pass 
-    all the params received from the previous call (shop code, timestamp, 
+    all the params received from the previous call (shop, code, timestamp, 
     signature) as a dictionary and the method will verify
     the params, extract the temp code and then request your token:
 


### PR DESCRIPTION
Fixed step 4 to match the verification described in the official docs.
http://docs.shopify.com/api/tutorials/oauth

If you follow the current docs to the letter and pass (client_id, client_secret, code, timestamp, signature) to request_token() the verification will fail.
