### PR TITLE
Add python 3.4 to travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "2.7"
+  - "3.4"
 
 # command to install dependencies
 install: "python setup.py install"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-== Version 2.0.5 unreleased
+== Version 2.1.0 unreleased
 
+* Added python 3 compatibility
 * Add a specific exception for signature validation failures
 
 == Version 2.0.4

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name=NAME,
       scripts=['scripts/shopify_api.py'],
       license='MIT License',
       install_requires=[
-          'pyactiveresource>=2.0.0',
+          'pyactiveresource>=2.1.0',
           'PyYAML',
           'six',
       ],


### PR DESCRIPTION
@pickle27 for review

Now that pyactiveresource 2.1.0 has been released with its compatibility for python 3 we can have travis test our python 3.4 compatibility.
