### PR TITLE
Fixed RecurringApplicationCharges resources current method (Issue: 85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tags
 /ShopifyAPI.egg-info
 *.egg
 /.idea
+.DS_Store

--- a/shopify/resources/recurring_application_charge.py
+++ b/shopify/resources/recurring_application_charge.py
@@ -1,11 +1,21 @@
 from ..base import ShopifyResource
 
+def _get_first_by_status(resources, status):
+    for resource in resources:
+        if resource.status == status:
+            return resource
+    return None
+
 
 class RecurringApplicationCharge(ShopifyResource):
 
     @classmethod
     def current(cls):
-        return cls.find_first(status="active")
+        """
+        Returns first RecurringApplicationCharge object with status=active.
+        If not found, None will be returned.
+        """
+        return _get_first_by_status(cls.find(), "active")
 
     def cancel(self):
         self._load_attributes_from_response(self.destroy)

--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.0'
+VERSION = '2.1.1'

--- a/test/fixtures/recurring_application_charges.json
+++ b/test/fixtures/recurring_application_charges.json
@@ -1,0 +1,38 @@
+{
+  "recurring_application_charges": [
+    {
+      "activated_on": null,
+      "api_client_id": 755357713,
+      "billing_on": "2015-01-15T00:00:00+00:00",
+      "cancelled_on": null,
+      "created_at": "2015-01-16T11:45:44-05:00",
+      "id": 455696195,
+      "name": "Super Mega Plan",
+      "price": "15.00",
+      "return_url": "http://yourapp.com",
+      "status": "accepted",
+      "test": null,
+      "trial_days": 0,
+      "trial_ends_on": null,
+      "updated_at": "2015-01-16T11:46:56-05:00",
+      "decorated_return_url": "http://yourapp.com?charge_id=455696195"
+    },
+    {
+      "activated_on": "2015-01-15T00:00:00+00:00",
+      "api_client_id": 755357713,
+      "billing_on": "2015-01-15T00:00:00+00:00",
+      "cancelled_on": null,
+      "created_at": "2015-01-16T11:45:44-05:00",
+      "id": 455696195,
+      "name": "Super Mega Plan 2",
+      "price": "15.00",
+      "return_url": "http://yourapp.com",
+      "status": "active",
+      "test": null,
+      "trial_days": 0,
+      "trial_ends_on": null,
+      "updated_at": "2015-01-16T11:46:56-05:00",
+      "decorated_return_url": "http://yourapp.com?charge_id=455696195"
+    }
+  ]
+}

--- a/test/fixtures/recurring_application_charges_no_active.json
+++ b/test/fixtures/recurring_application_charges_no_active.json
@@ -1,0 +1,38 @@
+{
+  "recurring_application_charges": [
+    {
+      "activated_on": null,
+      "api_client_id": 755357713,
+      "billing_on": "2015-01-15T00:00:00+00:00",
+      "cancelled_on": null,
+      "created_at": "2015-01-16T11:45:44-05:00",
+      "id": 455696195,
+      "name": "Super Mega Plan",
+      "price": "15.00",
+      "return_url": "http://yourapp.com",
+      "status": "accepted",
+      "test": null,
+      "trial_days": 0,
+      "trial_ends_on": null,
+      "updated_at": "2015-01-16T11:46:56-05:00",
+      "decorated_return_url": "http://yourapp.com?charge_id=455696195"
+    },
+    {
+      "activated_on": "2015-01-15T00:00:00+00:00",
+      "api_client_id": 755357713,
+      "billing_on": "2015-01-15T00:00:00+00:00",
+      "cancelled_on": null,
+      "created_at": "2015-01-16T11:45:44-05:00",
+      "id": 455696195,
+      "name": "Super Mega Plan 2",
+      "price": "15.00",
+      "return_url": "http://yourapp.com",
+      "status": "rejected",
+      "test": null,
+      "trial_days": 0,
+      "trial_ends_on": null,
+      "updated_at": "2015-01-16T11:46:56-05:00",
+      "decorated_return_url": "http://yourapp.com?charge_id=455696195"
+    }
+  ]
+}

--- a/test/recurring_charge_test.py
+++ b/test/recurring_charge_test.py
@@ -7,3 +7,17 @@ class RecurringApplicationChargeTest(TestCase):
         self.fake("recurring_application_charges/35463/activate", method='POST',headers={'Content-length':'0', 'Content-type': 'application/json'}, body=" ")
         charge = shopify.RecurringApplicationCharge({'id': 35463})
         charge.activate()
+
+    def test_current_method_returns_active_charge(self):
+        # Test that current() class method correctly returns
+        # first RecurringApplicationCharge with active status
+        self.fake("recurring_application_charges")
+        charge = shopify.RecurringApplicationCharge.current()
+        self.assertEqual(charge.id, 455696195)
+
+    def test_current_method_returns_none_if_active_not_found(self):
+        # Test that current() class method correctly returns
+        # None if RecurringApplicationCharge with active status not found
+        self.fake("recurring_application_charges", body=self.load_fixture("recurring_application_charges_no_active"))
+        charge = shopify.RecurringApplicationCharge.current()
+        self.assertEqual(charge, None)


### PR DESCRIPTION
This pull request fixes issue https://github.com/Shopify/shopify_python_api/issues/85 where RecurringApplicationChrage's current() method didn't work as intended. Intend of the method was to easily find resource with status = "active" but as the api end point doesn't support filtering by that field any other resource could be returned.

This is now fixed by doing filtering in memory and returning resource with correct status or None if not found. 
```python
def _get_first_by_status(resources, status):
    for resource in resources:
        if resource.status == status:
            return resource
    return None


class RecurringApplicationCharge(ShopifyResource):

    @classmethod
    def current(cls):
        """
        Returns first RecurringApplicationCharge object with status=active.
        If not found, None will be returned.
        """
        return _get_first_by_status(cls.find(), "active")
```

Behaviour is similar to Ruby api. See: https://github.com/Shopify/shopify_api/blob/08a015701d828cc85e38eb5a232bbcfd54518983/lib/shopify_api/resources/recurring_application_charge.rb#L7