### PR TITLE
Update MD5 Signature validation to HMAC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 * Added Checkout resource
 * Updated to pyactiveresource v2.1.1 which includes a test-related bugfix
+* Changed OAuth validation from MD5 to HMAC-SHA256
 
 == Version 2.1.0
 

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -2,10 +2,6 @@ import time
 import hmac
 from hashlib import sha256
 try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
-try:
     import simplejson as json
 except ImportError:
     import json

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -1,4 +1,6 @@
 import time
+import hmac
+from hashlib import sha256
 try:
     from hashlib import md5
 except ImportError:
@@ -109,3 +111,14 @@ class Session(object):
                 sorted_params += k + "=" + str(params[k])
 
         return md5((cls.secret + sorted_params).encode('utf-8')).hexdigest() == signature
+
+    @classmethod
+    def calculate_hmac(cls, params):
+        """
+        Calculate the HMAC of the given parameters in line with Shopify's rules for OAuth authentication.
+        See http://docs.shopify.com/api/authentication/oauth#verification.
+        """
+        # Sort and combine query parameters into a single string, excluding those that should be removed and joining with '&'.
+        sorted_params = '&'.join(['{0}={1}'.format(k, params[k]) for k in sorted(params.keys()) if k not in ['signature', 'hmac']])
+        # Generate the hex digest for the sorted parameters using the secret.
+        return hmac.new(cls.secret, sorted_params, sha256).hexdigest()

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -118,4 +118,4 @@ class Session(object):
         # Sort and combine query parameters into a single string, excluding those that should be removed and joining with '&'.
         sorted_params = '&'.join(['{0}={1}'.format(k, params[k]) for k in sorted(params.keys()) if k not in ['signature', 'hmac']])
         # Generate the hex digest for the sorted parameters using the secret.
-        return hmac.new(cls.secret, sorted_params, sha256).hexdigest()
+        return hmac.new(cls.secret.encode(), sorted_params.encode(), sha256).hexdigest()

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -113,6 +113,18 @@ class SessionTest(TestCase):
         session = shopify.Session("testshop.myshopify.com", "any-token")
         self.assertEqual("https://testshop.myshopify.com/admin", session.site)
 
+    def test_hmac_calculation(self):
+        # Test using the secret and parameter examples given in the Shopify API documentation.
+        shopify.Session.secret='hush'
+        params = {
+          'shop': 'some-shop.myshopify.com',
+          'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
+          'timestamp': '1337178173',
+          'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
+          'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
+        }
+        self.assertEqual(shopify.Session.calculate_hmac(params), params['hmac'])
+
     def test_return_token_if_signature_is_valid(self):
         shopify.Session.secret='secret'
         params = {'code': 'any-code', 'timestamp': time.time()}

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -159,14 +159,6 @@ class SessionTest(TestCase):
             session = shopify.Session('http://localhost.myshopify.com')
             session = session.request_token(params)
 
-
-    def make_sorted_params(self, params):
-        sorted_params = ""
-        for k in sorted(params.keys()):
-            if k != "signature":
-                sorted_params += k + "=" + str(params[k])
-        return sorted_params
-
     def normalize_url(self, url):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
         query = "&".join(sorted(query.split("&")))


### PR DESCRIPTION
This PR replaces the soon-to-be-deprecated MD5 method of OAuth validation with the HMAC-SHA256 method described [in the Shopify OAuth documentation](http://docs.shopify.com/api/authentication/oauth#verification).

It includes the addition of a few tests to verify that the HMAC calculation is being performed correctly (based on the examples in the Shopify documentation) and replaces tests verifying the calculation of the `signature` parameter with their `hmac` equivalents.

Has been tested in a live production environment without any problems. This PR closes #84.