### PR TITLE
Fix for prefix issue in base_test.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 == Version 2.1.1 (unreleased)
 
 * Added Checkout resource
+* Updated to pyactiveresource v2.1.1 which includes a test-related bugfix
 
 == Version 2.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name=NAME,
       scripts=['scripts/shopify_api.py'],
       license='MIT License',
       install_requires=[
-          'pyactiveresource>=2.1.0',
+          'pyactiveresource>=2.1.1',
           'PyYAML',
           'six',
       ],

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -59,8 +59,9 @@ class BaseTest(TestCase):
         shopify.ShopifyResource.set_headers({'X-Custom': 'abc'})
 
         with patch('shopify.ShopifyResource.connection.delete') as mock:
+            url = shopify.ShopifyResource._custom_method_collection_url('1', {})
             shopify.ShopifyResource.delete('1')
-            mock.assert_called_with('/admin/shopify_resources/1.json', {'X-Custom': 'abc'})
+            mock.assert_called_with(url, {'X-Custom': 'abc'})
 
         shopify.ShopifyResource.set_headers(org_headers)
 

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -41,7 +41,7 @@ class BaseTest(TestCase):
 
     def test_activate_session_with_one_session_then_clearing_and_activating_with_another_session_shoul_request_to_correct_shop(self):
         shopify.ShopifyResource.activate_session(self.session1)
-        shopify.ShopifyResource.clear_session
+        shopify.ShopifyResource.clear_session()
         shopify.ShopifyResource.activate_session(self.session2)
 
         self.assertIsNone(ActiveResource.site)


### PR DESCRIPTION
After [this change](https://github.com/Shopify/pyactiveresource/pull/12) to pyactiveresource, `test_delete_should_send_custom_headers_with_request` was failing due to inconsistent expected and actual URLs. This failure was causing other tests to fail as `shopify.ShopifyResource.set_headers` weren't being reset after the failure.