### PR TITLE
Fix unicode buffer issue

### DIFF
--- a/shopify/session.py
+++ b/shopify/session.py
@@ -99,8 +99,8 @@ class Session(object):
         if 'hmac' not in params:
             return False
 
-        hmac_calculated = cls.calculate_hmac(params)
-        hmac_to_verify = params['hmac']
+        hmac_calculated = cls.calculate_hmac(params).encode('utf-8')
+        hmac_to_verify = params['hmac'].encode('utf-8')
 
         # Try to use compare_digest() to reduce vulnerability to timing attacks.
         # If it's not available, just fall back to regular string comparison.

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -6,6 +6,7 @@ except ImportError:
     from md5 import md5
 import time
 from six.moves import urllib
+from six import u
 
 class SessionTest(TestCase):
 
@@ -133,7 +134,7 @@ class SessionTest(TestCase):
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
           'timestamp': '1337178173',
           'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
-          'hmac': unicode('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
+          'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
         }
         self.assertTrue(shopify.Session.validate_hmac(params))
 

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -125,6 +125,18 @@ class SessionTest(TestCase):
         }
         self.assertEqual(shopify.Session.calculate_hmac(params), params['hmac'])
 
+    def test_hmac_validation(self):
+        # Test using the secret and parameter examples given in the Shopify API documentation.
+        shopify.Session.secret='hush'
+        params = {
+          'shop': 'some-shop.myshopify.com',
+          'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
+          'timestamp': '1337178173',
+          'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
+          'hmac': unicode('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
+        }
+        self.assertTrue(shopify.Session.validate_hmac(params))
+
     def test_return_token_if_hmac_is_valid(self):
         shopify.Session.secret='secret'
         params = {'code': 'any-code', 'timestamp': time.time()}


### PR DESCRIPTION
In some cases, the `params` passed to `validate_hmac` could be in Unicode format. This causes issues for the `hmac.compare_digest` function (see [this similar issue](https://github.com/mitsuhiko/werkzeug/issues/537)).

This issue would not be apparent to any system running Python < 2.7.7, as `compare_digest` isn't available on 2.7.6 and lower.

This PR adds a failing test for the Unicode test and fixes the issue by ensuring both arguments to `compare_digest` are UTF-8 encoded.