### PR TITLE
Adds Location module and tests (closes #113)

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -47,5 +47,6 @@ from .smart_collection import SmartCollection
 from .gift_card import GiftCard
 from .discount import Discount
 from .shipping_zone import ShippingZone
+from .location import Location
 
 from ..base import ShopifyResource

--- a/shopify/resources/location.py
+++ b/shopify/resources/location.py
@@ -1,0 +1,5 @@
+from ..base import ShopifyResource
+
+
+class Location(ShopifyResource):
+    pass

--- a/test/fixtures/location.json
+++ b/test/fixtures/location.json
@@ -1,0 +1,19 @@
+{
+  "location": {
+    "id": 487838322,
+    "name": "Fifth Avenue AppleStore",
+    "deleted_at": null,
+    "address1": null,
+    "address2": null,
+    "city": null,
+    "zip": null,
+    "province": null,
+    "country": "US",
+    "phone": null,
+    "created_at": "2015-12-08T11:44:58-05:00",
+    "updated_at": "2015-12-08T11:44:58-05:00",
+    "country_code": "US",
+    "country_name": "United States",
+    "province_code": null
+  }
+}

--- a/test/fixtures/locations.json
+++ b/test/fixtures/locations.json
@@ -1,0 +1,38 @@
+{
+  "locations": [
+    {
+      "id": 487838322,
+      "name": "Fifth Avenue AppleStore",
+      "deleted_at": null,
+      "address1": null,
+      "address2": null,
+      "city": null,
+      "zip": null,
+      "province": null,
+      "country": "US",
+      "phone": null,
+      "created_at": "2015-12-08T11:44:58-05:00",
+      "updated_at": "2015-12-08T11:44:58-05:00",
+      "country_code": "US",
+      "country_name": "United States",
+      "province_code": null
+    },
+    {
+      "id": 1034478814,
+      "name": "Berlin Store",
+      "deleted_at": null,
+      "address1": null,
+      "address2": null,
+      "city": null,
+      "zip": null,
+      "province": null,
+      "country": "DE",
+      "phone": null,
+      "created_at": "2015-12-08T11:44:58-05:00",
+      "updated_at": "2015-12-08T11:44:58-05:00",
+      "country_code": "DE",
+      "country_name": "Germany",
+      "province_code": null
+    }
+  ]
+}

--- a/test/locations_test.py
+++ b/test/locations_test.py
@@ -1,0 +1,14 @@
+import shopify
+from test.test_helper import TestCase
+
+class LocationsTest(TestCase):
+    def test_fetch_locations(self):
+        self.fake("locations", method='GET', body=self.load_fixture('locations'))
+        locations = shopify.Location.find()
+        self.assertEqual(2,len(locations))
+
+    def test_fetch_location(self):
+        self.fake("locations/487838322", method='GET', body=self.load_fixture('location'))
+        location = shopify.Location.find(487838322)
+        self.assertEqual(location.id,487838322)
+        self.assertEqual(location.name,"Fifth Avenue AppleStore")


### PR DESCRIPTION
Hey guys,

it seems Locations endpoint was missing in the API, and as `shipping_zones`, there was not much trouble in including it.

I have also set up the tests for both collection and single location search