### PR TITLE
add usage_charge resource and update recurring charge

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -19,6 +19,7 @@ from .script_tag import ScriptTag
 from .product_search_engine import ProductSearchEngine
 from .application_charge import ApplicationCharge
 from .recurring_application_charge import RecurringApplicationCharge
+from .usage_charge import UsageCharge
 from .asset import Asset
 from .theme import Theme
 from .customer_saved_search import CustomerSavedSearch

--- a/shopify/resources/recurring_application_charge.py
+++ b/shopify/resources/recurring_application_charge.py
@@ -1,5 +1,5 @@
 from ..base import ShopifyResource
-import shopify
+from .usage_charge import UsageCharge
 
 def _get_first_by_status(resources, status):
     for resource in resources:
@@ -11,7 +11,7 @@ def _get_first_by_status(resources, status):
 class RecurringApplicationCharge(ShopifyResource):
 
     def usage_charges(self):
-        return shopify.UsageCharge.find(recurring_application_charge_id=self.id)
+        return UsageCharge.find(recurring_application_charge_id=self.id)
 
     def customize(self, **kwargs):
         self._load_attributes_from_response(self.put("customize", recurring_application_charge= kwargs))

--- a/shopify/resources/recurring_application_charge.py
+++ b/shopify/resources/recurring_application_charge.py
@@ -1,4 +1,5 @@
 from ..base import ShopifyResource
+import shopify
 
 def _get_first_by_status(resources, status):
     for resource in resources:
@@ -8,6 +9,12 @@ def _get_first_by_status(resources, status):
 
 
 class RecurringApplicationCharge(ShopifyResource):
+
+    def usage_charges(self):
+        return shopify.UsageCharge.find(recurring_application_charge_id=self.id)
+
+    def customize(self, **kwargs):
+        self._load_attributes_from_response(self.put("customize", recurring_application_charge= kwargs))
 
     @classmethod
     def current(cls):

--- a/shopify/resources/usage_charge.py
+++ b/shopify/resources/usage_charge.py
@@ -1,0 +1,12 @@
+from ..base import ShopifyResource
+
+class UsageCharge(ShopifyResource):
+    _prefix_source = "/admin/recurring_application_charge/$recurring_application_charge_id/"
+
+    @classmethod
+    def _prefix(cls, options={}):
+        recurring_application_charge_id = options.get("recurring_application_charge_id")
+        if recurring_application_charge_id:
+            return "/admin/recurring_application_charges/%s" % (recurring_application_charge_id)
+        else:
+            return "/admin"

--- a/test/fixtures/recurring_application_charge_adjustment.json
+++ b/test/fixtures/recurring_application_charge_adjustment.json
@@ -1,0 +1,5 @@
+{
+  "recurring_application_charge": {
+    "update_capped_amount_url": "http://apple.myshopify.com/admin/charges/654381177/confirm_update_capped_amount?signature=BAhpBHkQASc%3D--419fc7424f8c290ac2b21b9004ed223e35b52164"
+  }
+}

--- a/test/fixtures/recurring_application_charges.json
+++ b/test/fixtures/recurring_application_charges.json
@@ -32,7 +32,9 @@
       "trial_days": 0,
       "trial_ends_on": null,
       "updated_at": "2015-01-16T11:46:56-05:00",
-      "decorated_return_url": "http://yourapp.com?charge_id=455696195"
+      "decorated_return_url": "http://yourapp.com?charge_id=455696195",
+      "capped_amount": 100,
+      "terms": "$1 for 1000 emails"
     }
   ]
 }

--- a/test/fixtures/usage_charge.json
+++ b/test/fixtures/usage_charge.json
@@ -1,0 +1,11 @@
+{
+  "usage_charge": {
+    "id": 359376002,
+    "description": "1000 emails",
+    "price": "9.00",
+    "recurring_application_charge_id": 654381177,
+    "billing_on": "2015-07-08",
+    "balance_remaining": "91.00",
+    "balance_used": "9.00"
+  }
+}

--- a/test/fixtures/usage_charges.json
+++ b/test/fixtures/usage_charges.json
@@ -1,0 +1,23 @@
+{
+  "usage_charges": [
+    {
+      "id": 359376005,
+      "description": "1000 emails",
+      "price": "9.00",
+      "recurring_application_charge_id": 654381177,
+      "billing_on": "2015-07-08",
+      "balance_remaining": "82.00",
+      "balance_used": "18.00"
+
+    },
+    {
+      "id": 359376006,
+      "description": "1000 emails",
+      "price": "9.00",
+      "recurring_application_charge_id": 654381177,
+      "billing_on": "2015-07-08",
+      "balance_remaining": "82.00",
+      "balance_used": "18.00"
+    }
+  ]
+}

--- a/test/usage_charge_test.py
+++ b/test/usage_charge_test.py
@@ -1,0 +1,16 @@
+import shopify
+from test.test_helper import TestCase
+
+class UsageChargeTest(TestCase):
+    def test_create_usage_charge(self):
+        self.fake("recurring_application_charges/654381177/usage_charges", method='POST', body=self.load_fixture('usage_charge'), headers={'Content-type': 'application/json'})
+
+        charge = shopify.UsageCharge({'price': 9.0, 'description': '1000 emails', 'recurring_application_charge_id': 654381177})
+        charge.save()
+        self.assertEqual('1000 emails', charge.description)
+
+    def test_get_usage_charge(self):
+        self.fake("recurring_application_charges/654381177/usage_charges/359376002", method='GET', body=self.load_fixture('usage_charge'))
+
+        charge = shopify.UsageCharge.find(359376002, recurring_application_charge_id= 654381177)
+        self.assertEqual('1000 emails', charge.description)


### PR DESCRIPTION
## Description
- adds support for `usage_charge` resource
- adds `#customize` and `#usage_charges` to `recurring_application_charge`

@Shopify/finance @dominiquesr @kevinhughes27 @dylanahsmith 