### PR TITLE
Remove the Python3 limitation

### DIFF
--- a/index.md
+++ b/index.md
@@ -180,7 +180,6 @@ Use the `bin/shopify_api.py` script when running from the source tree. It will a
 
 Currently there is no support for:
 
-* python 3
 * asynchronous requests
 * persistent connections
 


### PR DESCRIPTION
Hello !

I'm studying the Python and noticed that Python3 support was added in the 2.1.0 version.

Thanks =)