### PR TITLE
Add tox for testing and Python 3.5 test support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 
 # command to install dependencies
 install: "python setup.py install"

--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ To run tests, simply open up the project directory in a terminal and run:
 python setup.py test
 ```
 
+Alternatively, use [tox](http://tox.readthedocs.org/en/latest/) to
+sequentially test against different versions of Python in isolated
+environments:
+
+```shell
+pip install tox
+tox
+```
+
+See the tox documentation for help on running only specific environments
+at a time. The related tool [detox](https://pypi.python.org/pypi/detox)
+can be used to run tests in these environments in parallel:
+
+```shell
+pip install detox
+detox
+```
+
 ## Limitations
 
 Currently there is no support for:

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name=NAME,
                    'Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3',
                    'Programming Language :: Python :: 3.4',
+                   'Programming Language :: Python :: 3.5',
                    'Topic :: Software Development',
                    'Topic :: Software Development :: Libraries',
                    'Topic :: Software Development :: Libraries :: Python Modules']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, pypy, pypy3
+envlist = py27, py34, py35
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27, py34, py35, pypy, pypy3
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/shopify
+commands = python setup.py test
+
+[testenv:flake8]
+basepython=python
+deps=
+    flake8
+    flake8_docstrings
+commands=
+    flake8 shopify
+
+[flake8]
+ignore = E126,E128
+max-line-length = 99
+exclude = .ropeproject
+max-complexity = 10


### PR DESCRIPTION
Creates isolated test environments for conveniently testing against multiple Python versions.

The tox configuration here tests against Python 2.7, Python 3.4, Python 3.5, PyPy, and PyPy3 by default. Given that the issues referenced in #114 and #117 have to do with build isolation, this should resolve those issues (have not experienced them, that much I'm certain about).