### PR TITLE
Removed all references in code to deprecated signature parameter

### DIFF
--- a/shopify/session.py
+++ b/shopify/session.py
@@ -136,7 +136,7 @@ class Session(object):
         """
         def encoded_pairs(params):
             for k, v in six.iteritems(params):
-                if k not in ['signature', 'hmac']:
+                if k != 'hmac':
                     # escape delimiters to avoid tampering
                     k = str(k).replace("%", "%25").replace("=", "%3D")
                     v = str(v).replace("%", "%25")

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -129,7 +129,6 @@ class SessionTest(TestCase):
           'shop': 'some-shop.myshopify.com',
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
           'timestamp': '1337178173',
-          'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
           'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
         }
         self.assertEqual(shopify.Session.calculate_hmac(params), params['hmac'])
@@ -148,7 +147,6 @@ class SessionTest(TestCase):
           'shop': 'some-shop.myshopify.com',
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
           'timestamp': '1337178173',
-          'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
           'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
         }
         self.assertTrue(shopify.Session.validate_hmac(params))
@@ -156,17 +154,6 @@ class SessionTest(TestCase):
     def test_return_token_if_hmac_is_valid(self):
         shopify.Session.secret='secret'
         params = {'code': 'any-code', 'timestamp': time.time()}
-        hmac = shopify.Session.calculate_hmac(params)
-        params['hmac'] = hmac
-
-        self.fake(None, url='https://localhost.myshopify.com/admin/oauth/access_token', method='POST', body='{"access_token" : "token"}', has_user_agent=False)
-        session = shopify.Session('http://localhost.myshopify.com')
-        token = session.request_token(params)
-        self.assertEqual("token", token)
-
-    def test_return_token_if_hmac_is_valid_but_signature_also_provided(self):
-        shopify.Session.secret='secret'
-        params = {'code': 'any-code', 'timestamp': time.time(), 'signature': '6e39a2'}
         hmac = shopify.Session.calculate_hmac(params)
         params['hmac'] = hmac
 


### PR DESCRIPTION
Removing all references in the code to the deprecated `signature` parameter which is no longer provided by Shopify in the interest of cleaning up the codebase and reducing confusion for partners.

I removed the test for `test_return_token_if_hmac_is_valid_but_signature_also_provided` since its no longer applicable but I wasn't sure about `test_raise_error_if_params_passed_but_signature_omitted` - is this testing if `signature` and `hmac` are omitted?

@kevinhughes27 @dylanahsmith @ShayneP 