### PR TITLE
Upgrade of `Session.create_permission_url`

### DIFF
--- a/shopify/session.py
+++ b/shopify/session.py
@@ -43,9 +43,9 @@ class Session(object):
         self.token = token
         return
 
-    def create_permission_url(self, scope, redirect_uri=None):
-        query_params = dict(client_id=self.api_key, scope=",".join(scope))
-        if redirect_uri: query_params['redirect_uri'] = redirect_uri
+    def create_permission_url(self, scope, redirect_uri, state=None):
+        query_params = dict(client_id=self.api_key, scope=",".join(scope), redirect_uri=redirect_uri)
+        if state: query_params['state'] = state
         return "%s/oauth/authorize?%s" % (self.site, urllib.parse.urlencode(query_params))
 
     def request_token(self, params):

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -80,13 +80,6 @@ class SessionTest(TestCase):
         self.assertEqual('https://testshop.myshopify.com/admin', assigned_site)
         self.assertEqual('https://None/admin', shopify.ShopifyResource.site)
 
-    def test_create_permission_url_returns_correct_url_with_single_scope_no_redirect_uri(self):
-        shopify.Session.setup(api_key="My_test_key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com')
-        scope = ["write_products"]
-        permission_url = session.create_permission_url(scope)
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", self.normalize_url(permission_url))
-
     def test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com')
@@ -94,19 +87,33 @@ class SessionTest(TestCase):
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
         self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products", self.normalize_url(permission_url))
 
-    def test_create_permission_url_returns_correct_url_with_dual_scope_no_redirect_uri(self):
+    def test_create_permission_url_returns_correct_url_with_dual_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com')
         scope = ["write_products","write_customers"]
-        permission_url = session.create_permission_url(scope)
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products%2Cwrite_customers", self.normalize_url(permission_url))
+        permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products%2Cwrite_customers", self.normalize_url(permission_url))
 
-    def test_create_permission_url_returns_correct_url_with_no_scope_no_redirect_uri(self):
+    def test_create_permission_url_returns_correct_url_with_no_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com')
         scope = []
-        permission_url = session.create_permission_url(scope)
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=", self.normalize_url(permission_url))
+        permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=", self.normalize_url(permission_url))
+
+    def test_create_permission_url_returns_correct_url_with_no_scope_and_redirect_uri_and_state(self):
+        shopify.Session.setup(api_key="My_test_key", secret="My test secret")
+        session = shopify.Session('http://localhost.myshopify.com')
+        scope = []
+        permission_url = session.create_permission_url(scope, "my_redirect_uri.com", state="mystate")
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=&state=mystate", self.normalize_url(permission_url))
+
+    def test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri_and_state(self):
+        shopify.Session.setup(api_key="My_test_key", secret="My test secret")
+        session = shopify.Session('http://localhost.myshopify.com')
+        scope = ["write_customers"]
+        permission_url = session.create_permission_url(scope, "my_redirect_uri.com", state="mystate")
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_customers&state=mystate", self.normalize_url(permission_url))
 
     def test_raise_exception_if_code_invalid_in_request_token(self):
         shopify.Session.setup(api_key="My test key", secret="My test secret")


### PR DESCRIPTION
#### Fixs #153 and fixs #154 

#### Features:
- `Session.create_permission_url` `redirect_uri` parameter is now required (#153)
- `Session.create_permission_url` has a new optional `state` parameter (#154)
- added and modified tests to fit the new behavior