### PR TITLE
fix #147: ensure image attachments are strings to be JSON-encodable

### DIFF
--- a/shopify/resources/image.py
+++ b/shopify/resources/image.py
@@ -23,7 +23,7 @@ class Image(ShopifyResource):
             return super(Image, self).__getattr__(name)
 
     def attach_image(self, data, filename=None):
-        self.attributes["attachment"] = base64.b64encode(data)
+        self.attributes["attachment"] = base64.b64encode(data).decode()
         if filename:
             self.attributes["filename"] = filename
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1,5 +1,6 @@
 import shopify
 from test.test_helper import TestCase
+import base64
 
 class ImageTest(TestCase):
 
@@ -12,6 +13,19 @@ class ImageTest(TestCase):
 
         self.assertEqual('http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540', image.src)
         self.assertEqual(850703190, image.id)
+
+    def test_attach_image(self):
+        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})
+        image = shopify.Image({'product_id':632910392})
+        image.position = 1
+        binary_in = base64.b64decode("R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf==")
+        image.attach_image(data=binary_in, filename='ipod-nano.png')
+        image.save()
+        binary_out = base64.b64decode(image.attachment)
+
+        self.assertEqual('http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540', image.src)
+        self.assertEqual(850703190, image.id)
+        self.assertEqual(binary_in, binary_out)
 
     def test_create_image_then_add_parent_id(self):
         self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})


### PR DESCRIPTION
As mentioned in #147, `attach_image` from `shopify.image` under Python 3 creates an image object that can't be saved, because the bytes array for the attachment can't be JSON-encoded.  This decodes the bytes back into a plain string.  (In Python 2 this same change seems to work without any complications, since it takes a string object to start with and decodes it into a unicode string containing the same ASCII-only bytes it started with.)

Thanks @pntt.