### PR TITLE
Delete service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,5 +1,0 @@
-# https://services.shopify.io/services/shopify_python_api/pypi
-director: jnormore
-owners: 
-- Shopify/partnerships-eng
-classification: tier3


### PR DESCRIPTION
Libraries should not have a `service.yml` AFAIK and partnerships-eng is not owning this.

