### PR TITLE
fix singular name for OrderRisk

### DIFF
--- a/shopify/resources/order_risk.py
+++ b/shopify/resources/order_risk.py
@@ -3,3 +3,4 @@ from ..base import ShopifyResource
 class OrderRisk(ShopifyResource):
   _prefix_source = "/admin/orders/$order_id/"
   _plural = "risks"
+  _singular = "risk"


### PR DESCRIPTION
the API actually uses "risk" for the singular name, not "order_risk" which is what is auto-generated from the OrderRisk class name