### PR TITLE
Fix order risk resource name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== Version 2.5.1
+* Fixed an issue preventing creation of Order Risk resources
+
 == Version 2.5.0
 * Added Price Rule and Discount Code resources
 

--- a/shopify/resources/order_risk.py
+++ b/shopify/resources/order_risk.py
@@ -2,4 +2,5 @@ from ..base import ShopifyResource
 
 class OrderRisk(ShopifyResource):
   _prefix_source = "/admin/orders/$order_id/"
+  _singular = "risk"
   _plural = "risks"

--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.0'
+VERSION = '2.5.1'


### PR DESCRIPTION
Singular resource name for OrderRisk was previously `order_risk`, as determined by the resource name.

This change updates the resource name to be `risk` (as per the API specification).

Also bumps version to `2.5.1` for release.