### PR TITLE
Add MarketingEvent resource

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -56,4 +56,5 @@ from .draft_order_invoice import DraftOrderInvoice
 from .report import Report
 from .price_rule import PriceRule
 from .discount_code import DiscountCode
+from .marketing_event import MarketingEvent
 from ..base import ShopifyResource

--- a/shopify/resources/marketing_event.py
+++ b/shopify/resources/marketing_event.py
@@ -1,0 +1,7 @@
+import json
+from ..base import ShopifyResource
+
+class MarketingEvent(ShopifyResource):
+    def add_engagements(self, engagements):
+        engagements_json = json.dumps({ 'engagements': engagements })
+        return self.post('engagements', engagements_json.encode())

--- a/test/fixtures/engagement.json
+++ b/test/fixtures/engagement.json
@@ -1,0 +1,15 @@
+{
+  "engagements": [
+    {
+      "occurred_on": "2017-04-20",
+      "impressions_count": null,
+      "views_count": null,
+      "clicks_count": 10,
+      "shares_count": null,
+      "favorites_count": null,
+      "comments_count": null,
+      "ad_spend": null,
+      "is_cumulative": true
+    }
+  ]
+}

--- a/test/fixtures/marketing_event.json
+++ b/test/fixtures/marketing_event.json
@@ -1,0 +1,28 @@
+{
+  "marketing_event": {
+    "id": 1,
+    "started_at": "2011-12-31T19:00:00-05:00",
+    "ended_at": null,
+    "event_target": "facebook",
+    "event_type": "post",
+    "scheduled_to_end_at": null,
+    "budget": "10.11",
+    "budget_type": "daily",
+    "currency": "GBP",
+    "utm_campaign": "1234567890",
+    "utm_source": "facebook",
+    "utm_medium": "facebook-post",
+    "utm_content": null,
+    "utm_term": null,
+    "manage_url": null,
+    "preview_url": null,
+    "description": null,
+    "marketing_channel": "social",
+    "paid": false,
+    "referring_domain": "facebook.com",
+    "breadcrumb_id": null,
+    "marketed_resources": [
+      { "type": "product", "id": 1 }
+    ]
+  }
+}

--- a/test/fixtures/marketing_events.json
+++ b/test/fixtures/marketing_events.json
@@ -1,0 +1,54 @@
+{
+  "marketing_event": [{
+    "id": 1,
+    "started_at": "2011-12-31T19:00:00-05:00",
+    "ended_at": null,
+    "event_target": "facebook",
+    "event_type": "post",
+    "scheduled_to_end_at": null,
+    "budget": "10.11",
+    "budget_type": "daily",
+    "currency": "GBP",
+    "utm_campaign": "1234567890",
+    "utm_source": "facebook",
+    "utm_medium": "facebook-post",
+    "utm_content": null,
+    "utm_term": null,
+    "manage_url": null,
+    "preview_url": null,
+    "description": null,
+    "marketing_channel": "social",
+    "paid": false,
+    "referring_domain": "facebook.com",
+    "breadcrumb_id": null,
+    "marketed_resources": [
+      { "type": "product", "id": 1 }
+    ]
+  },
+  {
+    "id": 2,
+    "started_at": "2011-12-31T19:00:00-05:00",
+    "ended_at": null,
+    "event_target": "facebook",
+    "event_type": "post",
+    "scheduled_to_end_at": null,
+    "budget": "10.11",
+    "budget_type": "daily",
+    "currency": "USD",
+    "utm_campaign": "1234567891",
+    "utm_source": "facebook",
+    "utm_medium": "facebook-post",
+    "utm_content": null,
+    "utm_term": null,
+    "manage_url": null,
+    "preview_url": null,
+    "description": null,
+    "marketing_channel": "social",
+    "paid": false,
+    "referring_domain": "facebook.com",
+    "breadcrumb_id": null,
+    "marketed_resources": [
+      { "type": "product", "id": 2 }
+    ]
+  }]
+}

--- a/test/marketing_event_test.py
+++ b/test/marketing_event_test.py
@@ -1,0 +1,85 @@
+import shopify
+import json
+from test.test_helper import TestCase
+
+
+class MarketingEventTest(TestCase):
+    def setUp(self):
+        super(MarketingEventTest, self).setUp()
+
+    def test_get_marketing_event(self):
+        self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
+        marketing_event = shopify.MarketingEvent.find(1)
+        self.assertEqual(marketing_event.id, 1)
+
+    def test_get_marketing_events(self):
+        self.fake('marketing_events', method='GET', body=self.load_fixture('marketing_events'))
+        marketing_events = shopify.MarketingEvent.find()
+        self.assertEqual(len(marketing_events), 2)
+
+    def test_create_marketing_event(self):
+        self.fake('marketing_events', method='POST', body=self.load_fixture('marketing_event'), headers={ 'Content-type': 'application/json' })
+
+        marketing_event = shopify.MarketingEvent()
+        marketing_event.currency_code = 'GBP'
+        marketing_event.event_target = 'facebook'
+        marketing_event.event_type = 'post'
+        marketing_event.save()
+
+        self.assertEqual(marketing_event.event_target, 'facebook')
+        self.assertEqual(marketing_event.currency_code, 'GBP')
+        self.assertEqual(marketing_event.event_type, 'post')
+
+    def test_delete_marketing_event(self):
+        self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
+        self.fake('marketing_events/1', method='DELETE', body='destroyed')
+
+        marketing_event = shopify.MarketingEvent.find(1)
+        marketing_event.destroy()
+
+        self.assertEqual('DELETE', self.http.request.get_method())
+
+    def test_update_marketing_event(self):
+        self.fake('marketing_events/1', method='GET', status=200, body=self.load_fixture('marketing_event'))
+        self.fake('marketing_events/1', method='PUT', status=200, body=self.load_fixture('marketing_event'), headers={'Content-type': 'application/json'})
+
+        marketing_event = shopify.MarketingEvent.find(1)
+        marketing_event.currency = 'USD'
+
+        self.assertTrue(marketing_event.save())
+
+    def test_count_marketing_events(self):
+        self.fake('marketing_events/count', method='GET', body='{"count": 2}')
+        marketing_events_count = shopify.MarketingEvent.count()
+        self.assertEqual(marketing_events_count, 2)
+
+    def test_add_engagements(self):
+        self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
+        self.fake(
+          'marketing_events/1/engagements',
+          method='POST',
+          status=201,
+          body=self.load_fixture('engagement'),
+          headers={'Content-type': 'application/json'}
+        )
+
+        marketing_event = shopify.MarketingEvent.find(1)
+        response = marketing_event.add_engagements([{
+            'occurred_on': '2017-04-20',
+            'impressions_count': None,
+            'views_count': None,
+            'clicks_count': 10,
+            'shares_count': None,
+            'favorites_count': None,
+            'comments_count': None,
+            'ad_spend': None,
+            'is_cumulative': True
+        }])
+
+        request_data = json.loads(self.http.request.data.decode("utf-8"))['engagements']
+        self.assertEqual(len(request_data), 1)
+        self.assertEqual(request_data[0]['occurred_on'], '2017-04-20')
+
+        response_data = json.loads(response.body.decode("utf-8"))['engagements']
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0]['occurred_on'], '2017-04-20')


### PR DESCRIPTION
This closes https://github.com/Shopify/merchant-marketing/issues/1645.

This PR adds the MarketingEvent resource, which behaves the same as the [Ruby API client counterpart](https://github.com/Shopify/shopify_api/blob/fcdd350f6652c9f97df5251ffc1fc85cc4de3e94/lib/shopify_api/resources/marketing_event.rb). 

---

# 🎩 

```python
>>> shopify.Order.count()
1
>>> shopify.MarketingEvent.count()
0

>>> event = shopify.MarketingEvent()
>>> event.event_type = 'ad'
>>> event.budget = '10.00'
>>> event.currency = 'USD'
>>> event.budget_type = 'lifetime'
>>> event.utm_campaign = 'CanadaDay2016'
>>> event.utm_source = 'facebook'
>>> event.utm_medium = 'cpc'
>>> event.manage_url = 'https://mymarketingapp.com/ad/1234'
>>> event.preview_url = 'https://www.facebook.com/123456/'
>>> event.started_at = '2016-06-20T11:56:18-04:00'
>>> event.ended_at = '2016-06-26T11:56:18-04:00'
>>> event.scheduled_to_end_at = '2016-06-27T11:56:18-04:00'
>>> event.description = 'Facebook carousel ad'
>>> event.marketing_channel = 'social'
>>> event.paid = True
>>> event.referring_domain = 'facebook.com'
>>> event.save()
True

>> response = event.add_engagements([{ "occurred_on": "2016-06-29", "impressions_count": 100, "clicks_count": 50, "shares_count": 10, "favorites_count": 20, "comments_count": 2, "ad_spend": "7.00", "is_cumulative": False }, { "occurred_on": "2016-06-30", "impressions_count": 200, "clicks_count": 100, "shares_count": 20, "favorites_count": 40, "comments_count": 4, "ad_spend": "6.50", "is_cumulative": True }])
>>> json.loads(response.body.decode())
{'engagements': [{'occurred_on': '2016-06-29', 'views_count': None, 'impressions_count': 100, 'clicks_count': 50, 'favorites_count': 20, 'comments_count': 2, 'shares_count': 10, 'ad_spend': '7.0', 'is_cumulative': False}, {'occurred_on': '2016-06-30', 'views_count': None, 'impressions_count': 200, 'clicks_count': 100, 'favorites_count': 40, 'comments_count': 4, 'shares_count': 20, 'ad_spend': '6.5', 'is_cumulative': True}]}

>>> shopify.MarketingEvent.find()
[marketing_event(5), marketing_event(7)]
>>> event = shopify.MarketingEvent.find(7)
>>> event.__dict__
{'klass': <class 'shopify.resources.marketing_event.MarketingEvent'>, 'attributes': {'id': 7, 'event_target': '', 'event_type': 'ad', 'remote_id': None, 'started_at': '2016-06-20T11:56:18-04:00', 'ended_at': '2016-06-26T11:56:18-04:00', 'scheduled_to_end_at': '2016-06-27T11:56:18-04:00', 'budget': '10.0', 'currency': 'USD', 'manage_url': 'https://mymarketingapp.com/ad/1234', 'preview_url': 'https://www.facebook.com/123456/', 'utm_campaign': 'CanadaDay2016', 'utm_source': 'facebook', 'utm_medium': 'cpc', 'utm_content': None, 'utm_term': None, 'budget_type': 'lifetime', 'description': 'Facebook carousel ad', 'marketing_channel': 'social', 'paid': True, 'referring_domain': 'facebook.com', 'breadcrumb_id': None, 'marketed_resources': []}, '_prefix_options': {}, 'errors': <pyactiveresource.activeresource.Errors object at 0x1054e7c18>, '_initialized': True}
>>> event.destroy()
>>> shopify.MarketingEvent.find()
[marketing_event(5)]


```