### PR TITLE
Remove deprecated ProductSearchEngine

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -16,7 +16,6 @@ from .receipt import Receipt
 from .rule import Rule
 from .tax_line import TaxLine
 from .script_tag import ScriptTag
-from .product_search_engine import ProductSearchEngine
 from .application_charge import ApplicationCharge
 from .recurring_application_charge import RecurringApplicationCharge
 from .usage_charge import UsageCharge

--- a/shopify/resources/product_search_engine.py
+++ b/shopify/resources/product_search_engine.py
@@ -1,5 +1,0 @@
-from ..base import ShopifyResource
-
-
-class ProductSearchEngine(ShopifyResource):
-    pass


### PR DESCRIPTION
🔥 ProductSearchEngine since it doesn't exist in the Shopify API.

Closes https://github.com/Shopify/shopify_python_api/issues/206

