### PR TITLE
Add StorefrontAccessToken and ResourceFeedback

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -58,5 +58,7 @@ from .discount_code import DiscountCode
 from .marketing_event import MarketingEvent
 from .collection_listing import CollectionListing
 from .product_listing import ProductListing
+from .resource_feedback import ResourceFeedback
+from .storefront_access_token import StorefrontAccessToken
 
 from ..base import ShopifyResource

--- a/shopify/resources/resource_feedback.py
+++ b/shopify/resources/resource_feedback.py
@@ -1,0 +1,14 @@
+from ..base import ShopifyResource
+
+
+class ResourceFeedback(ShopifyResource):
+    _prefix_source = "/admin/products/$product_id/"
+    _plural = "resource_feedback"
+
+    @classmethod
+    def _prefix(cls, options={}):
+        product_id = options.get("product_id")
+        if product_id:
+            return "/admin/products/%s" % product_id
+        else:
+            return "/admin"

--- a/shopify/resources/storefront_access_token.py
+++ b/shopify/resources/storefront_access_token.py
@@ -1,0 +1,5 @@
+from ..base import ShopifyResource
+
+
+class StorefrontAccessToken(ShopifyResource):
+    pass

--- a/test/fixtures/storefront_access_token.json
+++ b/test/fixtures/storefront_access_token.json
@@ -1,0 +1,9 @@
+{
+  "storefront_access_token": {
+    "id": 1,
+    "access_token": "477697f16c722efd66918cff7b3657a7",
+    "access_scope": "unauthenticated_read_product_listings",
+    "created_at": "2016-11-15T14:15:10-05:00",
+    "title": "Test"
+  }
+}

--- a/test/fixtures/storefront_access_tokens.json
+++ b/test/fixtures/storefront_access_tokens.json
@@ -1,0 +1,18 @@
+{
+  "storefront_access_tokens": [
+    {
+      "id": 1,
+      "access_token": "477697f16c722efd66918cff7b3657a7",
+      "access_scope": "unauthenticated_read_product_listings",
+      "created_at": "2016-11-15T14:15:10-05:00",
+      "title": "Test 1"
+    },
+    {
+      "id": 2,
+      "access_token": "477697f16c722efd66918cff7b3657a7",
+      "access_scope": "unauthenticated_read_product_listings",
+      "created_at": "2016-11-15T14:15:10-05:00",
+      "title": "Test 2"
+    }
+  ]
+}

--- a/test/resource_feedback_test.py
+++ b/test/resource_feedback_test.py
@@ -1,0 +1,37 @@
+import json
+import shopify
+from test.test_helper import TestCase
+
+class ResourceFeedbackTest(TestCase):
+    def test_get_resource_feedback(self):
+        body = json.dumps({ 'resource_feedback': [ { 'resource_type': 'Shop' } ] })
+        self.fake('resource_feedback', method='GET', body=body)
+
+        feedback = shopify.ResourceFeedback.find()
+
+        self.assertEqual('Shop', feedback[0].resource_type)
+
+    def test_save_with_resource_feedback_endpoint(self):
+        body = json.dumps({ 'resource_feedback': {} })
+        self.fake('resource_feedback', method='POST', body=body, headers={ 'Content-Type': 'application/json' })
+
+        shopify.ResourceFeedback().save()
+
+        self.assertEqual(body, self.http.request.data.decode("utf-8"))
+
+    def test_get_resource_feedback_with_product_id(self):
+        body = json.dumps({ 'resource_feedback': [ { 'resource_type': 'Product' } ] })
+        self.fake('products/42/resource_feedback', method='GET', body=body)
+
+        feedback = shopify.ResourceFeedback.find(product_id=42)
+
+        self.assertEqual('Product', feedback[0].resource_type)
+
+    def test_save_with_product_id_resource_feedback_endpoint(self):
+        body = json.dumps({ 'resource_feedback': {} })
+        self.fake('products/42/resource_feedback', method='POST', body=body, headers={ 'Content-Type': 'application/json' })
+
+        feedback = shopify.ResourceFeedback({'product_id':42})
+        feedback.save()
+
+        self.assertEqual(body, self.http.request.data.decode("utf-8"))

--- a/test/storefront_access_token_test.py
+++ b/test/storefront_access_token_test.py
@@ -1,0 +1,27 @@
+import shopify
+from test.test_helper import TestCase
+
+class StorefrontAccessTokenTest(TestCase):
+    def test_create_storefront_access_token(self):
+        self.fake('storefront_access_tokens', method='POST', body=self.load_fixture('storefront_access_token'), headers={ 'Content-type': 'application/json' })
+        storefront_access_token = shopify.StorefrontAccessToken.create({'title': 'Test'})
+        self.assertEqual(1, storefront_access_token.id)
+        self.assertEqual("Test", storefront_access_token.title)
+
+    def test_get_and_delete_storefront_access_token(self):
+        self.fake('storefront_access_tokens/1', method='GET', status=200, body=self.load_fixture('storefront_access_token'))
+        storefront_access_token = shopify.StorefrontAccessToken.find(1)
+
+        self.fake('storefront_access_tokens/1', method='DELETE', status=200, body='destroyed')
+        storefront_access_token.destroy()
+        self.assertEqual('DELETE', self.http.request.get_method())
+
+    def test_get_storefront_access_tokens(self):
+        self.fake('storefront_access_tokens', method='GET', status=200, body=self.load_fixture('storefront_access_tokens'))
+        tokens = shopify.StorefrontAccessToken.find()
+
+        self.assertEqual(2, len(tokens))
+        self.assertEqual(1, tokens[0].id)
+        self.assertEqual(2, tokens[1].id)
+        self.assertEqual("Test 1", tokens[0].title)
+        self.assertEqual("Test 2", tokens[1].title)


### PR DESCRIPTION
Adds two new resources to the package:
* StorefrontAccessToken
* ResourceFeedback

This PR brings this package to parity (at least in terms of resource inclusion) with the current state of the proper Shopify Admin API.

One minor caveat is that ResourceFeedback will not raise an exception on save for persisted resources ([as it does in the Ruby version of this package](https://github.com/Shopify/shopify_api/blob/master/lib/shopify_api/resources/resource_feedback.rb#L14-L17)), as `pyactiveresource` would need to be extended to support the `persisted` attribute on resources.

Closes https://github.com/Shopify/shopify_python_api/issues/188 & https://github.com/Shopify/shopify_python_api/issues/185.