### PR TITLE
Handle bytes data for asset attachments

### DIFF
--- a/shopify/resources/asset.py
+++ b/shopify/resources/asset.py
@@ -48,7 +48,7 @@ class Asset(ShopifyResource):
             return data
         data = self.attributes.get("attachment")
         if data:
-            return base64.b64decode(data)
+            return base64.b64decode(data).decode()
 
     def __set_value(self, data):
         self.__wipe_value_attributes()
@@ -57,7 +57,7 @@ class Asset(ShopifyResource):
     value = property(__get_value, __set_value, None, "The asset's value or attachment")
 
     def attach(self, data):
-        self.attachment = base64.b64encode(data)
+        self.attachment = base64.b64encode(data).decode()
 
     def destroy(self):
         options = {"asset[key]": self.key}

--- a/test/asset_test.py
+++ b/test/asset_test.py
@@ -1,3 +1,5 @@
+import base64
+
 import shopify
 from test.test_helper import TestCase
 
@@ -39,3 +41,13 @@ class AssetTest(TestCase):
 
         self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid", extension=False, method='DELETE', body="{}")
         v.destroy()
+
+    def test_attach(self):
+        self.fake("themes/1/assets", method='PUT', body=self.load_fixture('asset'), headers={'Content-type': 'application/json'})
+        attachment = b'dGVzdCBiaW5hcnkgZGF0YTogAAE='
+        key = 'assets/test.jpeg'
+        theme_id = 1
+        asset = shopify.Asset({'key': key, 'theme_id': theme_id})
+        asset.attach(attachment)
+        asset.save()
+        self.assertEqual(base64.b64encode(attachment).decode(), asset.attributes['attachment'])


### PR DESCRIPTION
After upgrading a project to Python 3, attempting to call `attach()` on an `Asset` object would result in the following error: `TypeError: Object of type 'bytes' is not JSON serializable`.

Using the decode method resolves this.