### PR TITLE
Implement refund calculation for an order

### DIFF
--- a/shopify/resources/refund.py
+++ b/shopify/resources/refund.py
@@ -1,5 +1,34 @@
+import json
+
 from ..base import ShopifyResource
 
 
 class Refund(ShopifyResource):
     _prefix_source = "/admin/orders/$order_id/"
+
+    @classmethod
+    def calculate(cls, order_id, shipping=None, refund_line_items=None):
+        """
+        Calculates refund transactions based on line items and shipping.
+        When you want to create a refund, you should first use the calculate
+        endpoint to generate accurate refund transactions.
+
+        Args:
+           order_id: Order ID for which the Refund has to created.
+           shipping: Specify how much shipping to refund.
+           refund_line_items: A list of line item IDs and quantities to refund.
+        Returns:
+           Unsaved refund record
+        """
+        data = {}
+        if shipping:
+            data['shipping'] = shipping
+        data['refund_line_items'] = refund_line_items or []
+        body = {'refund': data}
+        resource = cls.post(
+            "calculate", order_id=order_id, body=json.dumps(body).encode()
+        )
+        return cls(
+            cls.format.decode(resource.body),
+            prefix_options={'order_id': order_id}
+        )

--- a/test/fixtures/refund_calculate.json
+++ b/test/fixtures/refund_calculate.json
@@ -1,0 +1,31 @@
+{
+  "refund": {
+    "shipping": {
+      "amount": "5.00",
+      "tax": "0.00",
+      "maximum_refundable": "5.00"
+    },
+    "refund_line_items": [
+      {
+        "quantity": 1,
+        "line_item_id": 518995019,
+        "price": "199.00",
+        "subtotal": "195.67",
+        "total_tax": "3.98",
+        "discounted_price": "199.00",
+        "discounted_total_price": "199.00",
+        "total_cart_discount_amount": "3.33"
+      }
+    ],
+    "transactions": [
+      {
+        "order_id": 450789469,
+        "amount": "41.94",
+        "kind": "suggested_refund",
+        "gateway": "bogus",
+        "parent_id": 801038806,
+        "maximum_refundable": "41.94"
+      }
+    ]
+  }
+}

--- a/test/refund_test.py
+++ b/test/refund_test.py
@@ -9,3 +9,20 @@ class RefundTest(TestCase):
     def test_should_find_a_specific_refund(self):
         refund = shopify.Refund.find(509562969, order_id=450789469)
         self.assertEqual("209.00", refund.transactions[0].amount)
+
+    def test_calculate_refund_for_order(self):
+        self.fake(
+            "orders/450789469/refunds/calculate",
+            method="POST",
+            code=201,
+            body=self.load_fixture('refund_calculate'),
+            headers={'Content-type': 'application/json'},
+        )
+        refund = shopify.Refund.calculate(
+            order_id=450789469,
+            refund_line_items=[{'line_item_id': 518995019, 'quantity': 1}]
+        )
+
+        self.assertEqual("suggested_refund", refund.transactions[0].kind)
+        self.assertEqual("41.94", refund.transactions[0].amount)
+        self.assertEqual(518995019, refund.refund_line_items[0].line_item_id)


### PR DESCRIPTION
As the documentation suggests:
    When you want to create a refund, you should first use the calculate
    endpoint to generate accurate refund transactions.

This implementation will give us an unsaved refund record. After this you have
to change the transaction kind to "refund" from "suggested_refund" as suggested
in the API documentation.