### PR TITLE
Use code parameter instead of status when invoking test helpers

### DIFF
--- a/test/collection_listing_test.py
+++ b/test/collection_listing_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 class CollectionListingTest(TestCase):
 
     def test_get_collection_listings(self):
-        self.fake('collection_listings', method='GET', status=200, body=self.load_fixture('collection_listings'))
+        self.fake('collection_listings', method='GET', code=200, body=self.load_fixture('collection_listings'))
 
         collection_listings = shopify.CollectionListing.find()
         self.assertEqual(1, len(collection_listings))
@@ -12,7 +12,7 @@ class CollectionListingTest(TestCase):
         self.assertEqual("Home page", collection_listings[0].title)
 
     def test_get_collection_listing(self):
-        self.fake('collection_listings/1', method='GET', status=200, body=self.load_fixture('collection_listing'))
+        self.fake('collection_listings/1', method='GET', code=200, body=self.load_fixture('collection_listing'))
 
         collection_listing = shopify.CollectionListing.find(1)
 
@@ -20,7 +20,7 @@ class CollectionListingTest(TestCase):
         self.assertEqual("Home page", collection_listing.title)
 
     def test_reload_collection_listing(self):
-        self.fake('collection_listings/1', method='GET', status=200, body=self.load_fixture('collection_listing'))
+        self.fake('collection_listings/1', method='GET', code=200, body=self.load_fixture('collection_listing'))
 
         collection_listing = shopify.CollectionListing()
         collection_listing.collection_id = 1
@@ -30,7 +30,7 @@ class CollectionListingTest(TestCase):
         self.assertEqual("Home page", collection_listing.title)
 
     def test_get_collection_listing_product_ids(self):
-        self.fake('collection_listings/1/product_ids', method='GET', status=200, body=self.load_fixture('collection_listing_product_ids'))
+        self.fake('collection_listings/1/product_ids', method='GET', code=200, body=self.load_fixture('collection_listing_product_ids'))
 
         collection_listing = shopify.CollectionListing()
         collection_listing.id = 1

--- a/test/discount_code_test.py
+++ b/test/discount_code_test.py
@@ -17,7 +17,7 @@ class DiscountCodeTest(TestCase):
         self.discount_code.code = 'BOGO'
         self.fake('price_rules/1213131/discount_codes/34',
                   method='PUT',
-                  status=200,
+                  code=200,
                   body=self.load_fixture('discount_code'),
                   headers={'Content-type': 'application/json'})
         self.discount_code.save()

--- a/test/draft_order_test.py
+++ b/test/draft_order_test.py
@@ -10,34 +10,34 @@ class DraftOrderTest(TestCase):
         self.draft_order = shopify.DraftOrder.find(517119332)
 
     def test_get_draft_order(self):
-        self.fake('draft_orders/517119332', method='GET', status=200, body=self.load_fixture('draft_order'))
+        self.fake('draft_orders/517119332', method='GET', code=200, body=self.load_fixture('draft_order'))
         draft_order = shopify.DraftOrder.find(517119332)
         self.assertEqual(517119332, draft_order.id)
 
     def test_get_all_draft_orders(self):
-        self.fake('draft_orders', method='GET', status=200, body=self.load_fixture('draft_orders'))
+        self.fake('draft_orders', method='GET', code=200, body=self.load_fixture('draft_orders'))
         draft_orders = shopify.DraftOrder.find()
         self.assertEqual(1, len(draft_orders))
         self.assertEqual(517119332, draft_orders[0].id)
 
     def test_get_count_draft_orders(self):
-        self.fake('draft_orders/count', method='GET', status=200, body='{"count": 16}')
+        self.fake('draft_orders/count', method='GET', code=200, body='{"count": 16}')
         draft_orders_count = shopify.DraftOrder.count()
         self.assertEqual(16, draft_orders_count)
 
     def test_create_draft_order(self):
-        self.fake('draft_orders', method='POST', status=201, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
+        self.fake('draft_orders', method='POST', code=201, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
         draft_order = shopify.DraftOrder.create({"line_items": [{ "quantity": 1, "variant_id": 39072856 }]})
         self.assertEqual(json.loads('{"draft_order": {"line_items": [{"quantity": 1, "variant_id": 39072856}]}}'), json.loads(self.http.request.data.decode("utf-8")))
 
     def test_create_draft_order_202(self):
-        self.fake('draft_orders', method='POST', status=202, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
+        self.fake('draft_orders', method='POST', code=202, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
         draft_order = shopify.DraftOrder.create({"line_items": [{ "quantity": 1, "variant_id": 39072856 }]})
         self.assertEqual(39072856, draft_order.line_items[0].variant_id)
 
     def test_update_draft_order(self):
         self.draft_order.note = 'Test new note'
-        self.fake('draft_orders/517119332', method='PUT', status=200, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
+        self.fake('draft_orders/517119332', method='PUT', code=200, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
         self.draft_order.save()
         self.assertEqual('Test new note', json.loads(self.http.request.data.decode("utf-8"))['draft_order']['note'])
 
@@ -65,7 +65,7 @@ class DraftOrderTest(TestCase):
         self.assertEqual('DELETE', self.http.request.get_method())
 
     def test_add_metafields_to_draft_order(self):
-        self.fake('draft_orders/517119332/metafields', method='POST', status=201, body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
+        self.fake('draft_orders/517119332/metafields', method='POST', code=201, body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
         field = self.draft_order.add_metafield(shopify.Metafield({'namespace': 'contact', 'key': 'email', 'value': '123@example.com', 'value_type': 'string'}))
         self.assertEqual(json.loads('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), json.loads(self.http.request.data.decode("utf-8")))
         self.assertFalse (field.is_new())

--- a/test/inventory_level_test.py
+++ b/test/inventory_level_test.py
@@ -63,5 +63,5 @@ class InventoryLevelTest(TestCase):
         })
         path = "inventory_levels.json?" + query_params
 
-        self.fake(path, extension=False, method='DELETE', status=204, body='{}')
+        self.fake(path, extension=False, method='DELETE', code=204, body='{}')
         inventory_level.destroy()

--- a/test/marketing_event_test.py
+++ b/test/marketing_event_test.py
@@ -40,8 +40,8 @@ class MarketingEventTest(TestCase):
         self.assertEqual('DELETE', self.http.request.get_method())
 
     def test_update_marketing_event(self):
-        self.fake('marketing_events/1', method='GET', status=200, body=self.load_fixture('marketing_event'))
-        self.fake('marketing_events/1', method='PUT', status=200, body=self.load_fixture('marketing_event'), headers={'Content-type': 'application/json'})
+        self.fake('marketing_events/1', method='GET', code=200, body=self.load_fixture('marketing_event'))
+        self.fake('marketing_events/1', method='PUT', code=200, body=self.load_fixture('marketing_event'), headers={'Content-type': 'application/json'})
 
         marketing_event = shopify.MarketingEvent.find(1)
         marketing_event.currency = 'USD'
@@ -58,7 +58,7 @@ class MarketingEventTest(TestCase):
         self.fake(
           'marketing_events/1/engagements',
           method='POST',
-          status=201,
+          code=201,
           body=self.load_fixture('engagement'),
           headers={'Content-type': 'application/json'}
         )

--- a/test/price_rules_test.py
+++ b/test/price_rules_test.py
@@ -12,7 +12,7 @@ class PriceRuleTest(TestCase):
         self.price_rule = shopify.PriceRule.find(1213131)
 
     def test_get_price_rule(self):
-        self.fake('price_rule/1213131', method='GET', status=200, body=self.load_fixture('price_rule'))
+        self.fake('price_rule/1213131', method='GET', code=200, body=self.load_fixture('price_rule'))
         price_rule = shopify.PriceRule.find(1213131)
         self.assertEqual(1213131, price_rule.id)
 
@@ -26,7 +26,7 @@ class PriceRuleTest(TestCase):
 
     def test_update_price_rule(self):
         self.price_rule.title = "Buy One Get One"
-        self.fake('price_rules/1213131', method='PUT', status=200, body=self.load_fixture('price_rule'), headers={'Content-type': 'application/json'})
+        self.fake('price_rules/1213131', method='PUT', code=200, body=self.load_fixture('price_rule'), headers={'Content-type': 'application/json'})
         self.price_rule.save()
         self.assertEqual('Buy One Get One', json.loads(self.http.request.data.decode("utf-8"))['price_rule']['title'])
 
@@ -56,7 +56,7 @@ class PriceRuleTest(TestCase):
         self.assertEqual("line_item", price_rule.target_type)
 
     def test_get_discount_codes(self):
-        self.fake('price_rules/1213131/discount_codes', method='GET', status=200, body=self.load_fixture('discount_codes'))
+        self.fake('price_rules/1213131/discount_codes', method='GET', code=200, body=self.load_fixture('discount_codes'))
         discount_codes = self.price_rule.discount_codes()
         self.assertEqual(1, len(discount_codes))
 

--- a/test/product_listing_test.py
+++ b/test/product_listing_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 class ProductListingTest(TestCase):
 
     def test_get_product_listings(self):
-        self.fake('product_listings', method='GET', status=200, body=self.load_fixture('product_listings'))
+        self.fake('product_listings', method='GET', code=200, body=self.load_fixture('product_listings'))
 
         product_listings = shopify.ProductListing.find()
         self.assertEqual(2, len(product_listings))
@@ -14,13 +14,13 @@ class ProductListingTest(TestCase):
         self.assertEqual("Rustic Copper Bottle", product_listings[1].title)
 
     def test_get_product_listing(self):
-        self.fake('product_listings/2', method='GET', status=200, body=self.load_fixture('product_listing'))
+        self.fake('product_listings/2', method='GET', code=200, body=self.load_fixture('product_listing'))
 
         product_listing = shopify.ProductListing.find(2)
         self.assertEqual("Synergistic Silk Chair", product_listing.title)
 
     def test_reload_product_listing(self):
-        self.fake('product_listings/2', method='GET', status=200, body=self.load_fixture('product_listing'))
+        self.fake('product_listings/2', method='GET', code=200, body=self.load_fixture('product_listing'))
 
         product_listing = shopify.ProductListing()
         product_listing.product_id = 2

--- a/test/storefront_access_token_test.py
+++ b/test/storefront_access_token_test.py
@@ -9,15 +9,15 @@ class StorefrontAccessTokenTest(TestCase):
         self.assertEqual("Test", storefront_access_token.title)
 
     def test_get_and_delete_storefront_access_token(self):
-        self.fake('storefront_access_tokens/1', method='GET', status=200, body=self.load_fixture('storefront_access_token'))
+        self.fake('storefront_access_tokens/1', method='GET', code=200, body=self.load_fixture('storefront_access_token'))
         storefront_access_token = shopify.StorefrontAccessToken.find(1)
 
-        self.fake('storefront_access_tokens/1', method='DELETE', status=200, body='destroyed')
+        self.fake('storefront_access_tokens/1', method='DELETE', code=200, body='destroyed')
         storefront_access_token.destroy()
         self.assertEqual('DELETE', self.http.request.get_method())
 
     def test_get_storefront_access_tokens(self):
-        self.fake('storefront_access_tokens', method='GET', status=200, body=self.load_fixture('storefront_access_tokens'))
+        self.fake('storefront_access_tokens', method='GET', code=200, body=self.load_fixture('storefront_access_tokens'))
         tokens = shopify.StorefrontAccessToken.find()
 
         self.assertEqual(2, len(tokens))


### PR DESCRIPTION
The test helper accepts the `code` parameter to set the status code in the mock response, but `status` was used in these tests erroneously (probably because that's what matches our test suite in `shopify_api`).

This PR replaces all instances of `status=` with `code=` in the tests.