### PR TITLE
Limits

### DIFF
--- a/shopify/__init__.py
+++ b/shopify/__init__.py
@@ -1,3 +1,4 @@
 from shopify.version import VERSION
 from shopify.session import Session, ValidationException
 from shopify.resources import *
+from shopify.limits import Limits

--- a/shopify/limits.py
+++ b/shopify/limits.py
@@ -1,0 +1,31 @@
+import shopify
+
+class Limits(object):
+    CREDIT_LIMIT_HEADER_PARAM = 'x-shopify-shop-api-call-limit'
+
+    @classmethod
+    def credit_left(cls):
+        return cls.credit_limit() - cls.credit_used()
+
+    @classmethod
+    def is_credit_maxed(cls):
+        return cls.credit_left() <= 0
+
+    @classmethod
+    def credit_limit(cls):
+        return int(cls._api_credit_limit_param()[1])
+
+    @classmethod
+    def credit_used(cls):
+        return int(cls._api_credit_limit_param()[0])
+
+    @classmethod
+    def _api_credit_limit_param(cls):
+        return cls._response().get(cls.CREDIT_LIMIT_HEADER_PARAM).split('/')
+
+    @classmethod
+    def _response(cls):
+        if not shopify.ShopifyResource.connection.response:
+            shopify.Shop.current()
+
+        return shopify.ShopifyResource.connection.response

--- a/test/limits_test.py
+++ b/test/limits_test.py
@@ -1,0 +1,40 @@
+import shopify
+from mock import patch
+from test.test_helper import TestCase
+
+class LimitsTest(TestCase):
+    def setUp(self):
+        super(LimitsTest, self).setUp()
+
+        mock = patch('shopify.ShopifyResource.connection.response.get', side_effect=self.mock_limit_headers)
+        mock.start()
+
+        self.fake('shop')
+        shopify.Shop.current()
+
+    def tearDown(self):
+        super(LimitsTest, self).tearDown()
+        patch.stopall()
+
+    def test_fetch_limits_total(self):
+        self.assertEqual(40, shopify.Limits.credit_limit())
+
+    def test_fetch_used_calls(self):
+        self.assertEqual(1, shopify.Limits.credit_used())
+
+    def test_calculate_remaining_calls(self):
+        self.assertEqual(39, shopify.Limits.credit_left())
+
+    def test_maxed_returns_true_when_credit_maxed_out(self):
+        self.assertFalse(shopify.Limits.is_credit_maxed())
+
+        with patch('shopify.ShopifyResource.connection.response.get', side_effect=self.mock_limit_headers_max) as mock:
+            self.assertTrue(shopify.Limits.is_credit_maxed())
+
+    def mock_limit_headers(self, key):
+        if key == shopify.Limits.CREDIT_LIMIT_HEADER_PARAM:
+            return '1/40'
+
+    def mock_limit_headers_max(self, key):
+        if key == shopify.Limits.CREDIT_LIMIT_HEADER_PARAM:
+            return '40/40'


### PR DESCRIPTION
Successor to #161.

To be honest, I'm sure if this is the best approach. I've added a `Limits` class which can be accessed through `shopify.Limits` but I'm not sure how "pythonic"  this approach is. Is there some way to make the methods available directly on the `shopify` instance? Would this be preferable?

Tests were a bit of a pain for me. If anyone is more familiar with `mock`, feel free to correct my usage here.