### PR TITLE
Add Python 3 compatibility for API console.

### DIFF
--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -10,6 +10,7 @@ import subprocess
 import functools
 import yaml
 import six
+from six.moves import input, map
 
 def start_interpreter(**variables):
     console = type('shopify ' + shopify.version.VERSION, (code.InteractiveConsole, object), {})
@@ -107,19 +108,19 @@ class Tasks(object):
             raise ConfigFileError("There is already a config file at " + filename)
         else:
             config = dict(protocol='https')
-            domain = raw_input("Domain? (leave blank for %s.myshopify.com) " % (connection))
+            domain = input("Domain? (leave blank for %s.myshopify.com) " % (connection))
             if not domain.strip():
                 domain = "%s.myshopify.com" % (connection)
             config['domain'] = domain
             print("")
             print("open https://%s/admin/apps/private in your browser to generate API credentials" % (domain))
-            config['api_key'] = raw_input("API key? ")
-            config['password'] = raw_input("Password? ")
+            config['api_key'] = input("API key? ")
+            config['password'] = input("Password? ")
             if not os.path.isdir(cls._shop_config_dir):
                 os.makedirs(cls._shop_config_dir)
             with open(filename, 'w') as f:
                 f.write(yaml.dump(config, default_flow_style=False, explicit_start="---"))
-        if len(cls._available_connections()) == 1:
+        if len(list(cls._available_connections())) == 1:
             cls.default(connection)
 
     @classmethod


### PR DESCRIPTION
Use the `six.moves` library to add Python 3 support for the API console while maintaining compatibility for Python 2.

Specifically, the calls to `input()` need to be handled differently in Python 2 & 3 – `raw_input()` is not supported in Python 3.

Also, in Python 2 `map` returns a list but in Python 3 `map` returns an iterator. Using `map` from `six.moves` delegates the call in Python 2 to `itertools.imap()` which also returns an iterator.