### PR TITLE
Add ApiPermission resource

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -63,5 +63,6 @@ from .storefront_access_token import StorefrontAccessToken
 from .inventory_item import InventoryItem
 from .inventory_level import InventoryLevel
 from .access_scope import AccessScope
+from .api_permission import ApiPermission
 
 from ..base import ShopifyResource

--- a/shopify/resources/api_permission.py
+++ b/shopify/resources/api_permission.py
@@ -1,0 +1,9 @@
+from ..base import ShopifyResource
+
+class ApiPermission(ShopifyResource):
+
+    @classmethod
+    def delete(cls):
+        cls.connection.delete('admin/api_permissions/current.' + cls.format.extension, cls.headers)
+
+    destroy = delete

--- a/test/api_permission_test.py
+++ b/test/api_permission_test.py
@@ -1,0 +1,14 @@
+import shopify
+from test.test_helper import TestCase
+
+class ApiPermissionTest(TestCase):
+
+    def test_delete_api_permission(self):
+        self.fake(
+            'api_permissions/current',
+            method='DELETE',
+            code=200,
+            body='{}'
+        )
+
+        shopify.ApiPermission.delete()


### PR DESCRIPTION
Adds support for the ApiPermission resource, which allows applications to programmatically uninstall themselves.

See the documentation [here](https://help.shopify.com/en/api/getting-started/authentication/oauth/uninstalling-applications) in the help center for more details.

Closes https://github.com/Shopify/shopify_python_api/issues/158.