### PR TITLE
Add support for PriceRule batch endpoint

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -55,6 +55,7 @@ from .draft_order_invoice import DraftOrderInvoice
 from .report import Report
 from .price_rule import PriceRule
 from .discount_code import DiscountCode
+from .discount_code_creation import DiscountCodeCreation
 from .marketing_event import MarketingEvent
 from .collection_listing import CollectionListing
 from .product_listing import ProductListing

--- a/shopify/resources/discount_code_creation.py
+++ b/shopify/resources/discount_code_creation.py
@@ -1,0 +1,10 @@
+from ..base import ShopifyResource
+from .discount_code import DiscountCode
+
+class DiscountCodeCreation(ShopifyResource):
+    _prefix_source = "/admin/price_rules/$price_rule_id/"
+
+    def discount_codes(self):
+        return DiscountCode.find(from_="/admin/price_rules/%s/batch/%s/discount_codes.%s" % (self._prefix_options['price_rule_id'],
+                                                                                             self.id,
+                                                                                             DiscountCodeCreation.format.extension))

--- a/shopify/resources/price_rule.py
+++ b/shopify/resources/price_rule.py
@@ -1,5 +1,7 @@
+import json
 from ..base import ShopifyResource
 from .discount_code import DiscountCode
+from .discount_code_creation import DiscountCodeCreation
 
 class PriceRule(ShopifyResource):
     def add_discount_code(self, discount_code = DiscountCode()):
@@ -8,3 +10,13 @@ class PriceRule(ShopifyResource):
 
     def discount_codes(self):
         return DiscountCode.find(price_rule_id=self.id)
+
+    def create_batch(self, codes = []):
+        codes_json = json.dumps({ 'discount_codes': codes})
+
+        response = self.post("batch", codes_json.encode())
+        return DiscountCodeCreation(PriceRule.format.decode(response.body))
+
+    def find_batch(self, batch_id):
+        return DiscountCodeCreation.find_one("admin/price_rules/%s/batch/%s.%s" % (self.id, batch_id,
+                                                                                   PriceRule.format.extension))

--- a/test/discount_code_creation_test.py
+++ b/test/discount_code_creation_test.py
@@ -1,0 +1,16 @@
+from test.test_helper import TestCase
+import shopify
+
+class DiscountCodeCreationTest(TestCase):
+    def test_find_batch_job_discount_codes(self):
+        self.fake('price_rules/1213131', body=self.load_fixture('price_rule'))
+        price_rule = shopify.PriceRule.find(1213131)
+
+        self.fake('price_rules/1213131/batch/989355119', body=self.load_fixture('discount_code_creation'))
+        batch = price_rule.find_batch(989355119)
+
+        self.fake('price_rules/1213131/batch/989355119/discount_codes', body=self.load_fixture('batch_discount_codes'))
+        discount_codes = batch.discount_codes()
+
+        self.assertEqual('foo', discount_codes[0].code)
+        self.assertEqual('bar', discount_codes[2].code)

--- a/test/fixtures/batch_discount_codes.json
+++ b/test/fixtures/batch_discount_codes.json
@@ -1,0 +1,19 @@
+{
+  "discount_codes": [
+    {
+      "id": null,
+      "code": "foo",
+      "errors": {}
+    },
+    {
+      "id": null,
+      "code": "",
+      "errors": {}
+    },
+    {
+      "id": null,
+      "code": "bar",
+      "errors": {}
+    }
+  ]
+}

--- a/test/fixtures/discount_code_creation.json
+++ b/test/fixtures/discount_code_creation.json
@@ -1,0 +1,14 @@
+{
+  "discount_code_creation": {
+    "id": 989355119,
+    "price_rule_id": 1213131,
+    "started_at": null,
+    "completed_at": null,
+    "created_at": "2018-07-05T13:04:29-04:00",
+    "updated_at": "2018-07-05T13:04:29-04:00",
+    "status": "queued",
+    "codes_count": 3,
+    "imported_count": 0,
+    "failed_count": 0
+  }
+}

--- a/test/price_rules_test.py
+++ b/test/price_rules_test.py
@@ -64,11 +64,31 @@ class PriceRuleTest(TestCase):
         price_rule_discount_fixture = self.load_fixture('discount_code')
         discount_code = json.loads(price_rule_discount_fixture.decode("utf-8"))
         self.fake('price_rules/1213131/discount_codes',
-                  method='POST', 
-                  body=price_rule_discount_fixture, 
+                  method='POST',
+                  body=price_rule_discount_fixture,
                   headers={'Content-type': 'application/json'})
         price_rule_discount_response = self.price_rule.add_discount_code(shopify.DiscountCode(discount_code['discount_code']))
         self.assertEqual(discount_code, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(price_rule_discount_response, shopify.DiscountCode)
         self.assertEqual(discount_code['discount_code']['code'], price_rule_discount_response.code)
 
+    def test_create_batch_discount_codes(self):
+        self.fake('price_rules/1213131/batch',
+                  method='POST',
+                  code=201,
+                  body=self.load_fixture('discount_code_creation'),
+                  headers={'Content-type': 'application/json'})
+        batch = self.price_rule.create_batch([{'code': 'SUMMER1'}, {'code': 'SUMMER2'}, {'code': 'SUMMER3'}])
+
+        self.assertEqual(3, batch.codes_count)
+        self.assertEqual('queued', batch.status)
+
+    def test_find_batch_job(self):
+        self.fake('price_rules/1213131/batch/989355119',
+                  method='GET',
+                  code=200,
+                  body=self.load_fixture('discount_code_creation'))
+        batch = self.price_rule.find_batch(989355119)
+
+        self.assertEqual(3, batch.codes_count)
+        self.assertEqual('queued', batch.status)


### PR DESCRIPTION
Adds support for the [batch operations](https://help.shopify.com/en/api/reference/discounts/discountcode#batch_create)  available in the PriceRule API.

Specifically, this PR:

* adds support for `create_batch()` and `find_batch()` on `shopify.PriceRule`
* adds a new `shopify.DiscountCodeCreation` resource, to represent the resource returned when creating and finding batch jobs
* adds support for `discount_codes()` on `shopify.DiscountCodeCreation`

Closes https://github.com/Shopify/shopify_python_api/issues/250.