### PR TITLE
Remove cancel() method for RecurringApplicationCharge

### DIFF
--- a/shopify/resources/recurring_application_charge.py
+++ b/shopify/resources/recurring_application_charge.py
@@ -24,8 +24,5 @@ class RecurringApplicationCharge(ShopifyResource):
         """
         return _get_first_by_status(cls.find(), "active")
 
-    def cancel(self):
-        self._load_attributes_from_response(self.destroy)
-
     def activate(self):
         self._load_attributes_from_response(self.post("activate"))

--- a/test/recurring_charge_test.py
+++ b/test/recurring_charge_test.py
@@ -38,3 +38,10 @@ class RecurringApplicationChargeTest(TestCase):
         self.fake("recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200", extension=False, method='PUT', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=self.load_fixture('recurring_application_charge_adjustment'))
         charge.customize(capped_amount= 200)
         self.assertTrue(charge.update_capped_amount_url)
+
+    def test_destroy_recurring_application_charge(self):
+        self.fake('recurring_application_charges')
+        charge = shopify.RecurringApplicationCharge.current()
+
+        self.fake('recurring_application_charges/455696195', method='DELETE', body='{}')
+        charge.destroy()


### PR DESCRIPTION
Closes https://github.com/Shopify/shopify_python_api/issues/190.

The `cancel` endpoint for RecurringApplication Charge doesn't return a body ([source](https://help.shopify.com/en/api/reference/billing/recurringapplicationcharge#destroy)), so `shopify.RecurringApplicationCharge.cancel()` throws an exception whenever its called since it tries to load an instance from the response.

The proper way to cancel a RecurringApplicationCharge is to simply call the `destroy()` method inherited from the parent ActiveResource class as demonstrated [here](https://github.com/Shopify/shopify_python_api/issues/190#issuecomment-427105097).