### PR TITLE
Add prefix source to AccessScope resource

### DIFF
--- a/shopify/resources/access_scope.py
+++ b/shopify/resources/access_scope.py
@@ -2,4 +2,4 @@ from ..base import ShopifyResource
 
 
 class AccessScope(ShopifyResource):
-    pass
+    _prefix_source = "/admin/oauth/"

--- a/test/access_scope_test.py
+++ b/test/access_scope_test.py
@@ -3,8 +3,8 @@ from test.test_helper import TestCase
 
 class AccessScopeTest(TestCase):
 
-  def test_all_should_return_all_checkouts(self):
-    self.fake('access_scopes')
+  def test_find_should_return_all_access_scopes(self):
+    self.fake('oauth/access_scopes', body=self.load_fixture('access_scopes'))
     scopes = shopify.AccessScope.find()
     self.assertEqual(3, len(scopes))
     self.assertEqual('read_products', scopes[0].handle)


### PR DESCRIPTION
Small fix for the `AccessScope` resource.

The `access_scope` endpoint is prefixed with `/admin/oauth`, so this PR adds the correct prefix.