### PR TITLE
Add TenderTransaction resource

### DIFF
--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -40,6 +40,7 @@ from .fulfillment import Fulfillment
 from .fulfillment_service import FulfillmentService
 from .carrier_service import CarrierService
 from .transaction import Transaction
+from .tender_transaction import TenderTransaction
 from .image import Image
 from .variant import Variant
 from .order import Order

--- a/shopify/resources/tender_transaction.py
+++ b/shopify/resources/tender_transaction.py
@@ -1,0 +1,4 @@
+from ..base import ShopifyResource
+
+class TenderTransaction(ShopifyResource):
+    _prefix_source = "/admin/"

--- a/shopify/resources/tender_transaction.py
+++ b/shopify/resources/tender_transaction.py
@@ -1,4 +1,4 @@
 from ..base import ShopifyResource
 
 class TenderTransaction(ShopifyResource):
-    _prefix_source = "/admin/"
+    pass

--- a/test/fixtures/tender_transactions.json
+++ b/test/fixtures/tender_transactions.json
@@ -1,0 +1,52 @@
+{
+  "tender_transactions": [
+    {
+      "id": 1,
+      "order_id": 450789469,
+      "amount": "138.46",
+      "currency": "CAD",
+      "user_id": null,
+      "test": true,
+      "processed_at": "2018-08-09T15:43:39-04:00",
+      "updated_at": "2018-08-09T15:43:41-04:00",
+      "remote_reference": "1118366",
+      "payment_method": "credit_card",
+      "payment_details": {
+        "credit_card_number": "•••• •••• •••• 1",
+        "credit_card_company": "Bogus"
+      }
+    },
+    {
+      "id": 2,
+      "order_id": 450789469,
+      "amount": "128.16",
+      "currency": "CAD",
+      "user_id": null,
+      "test": true,
+      "processed_at": "2018-08-11T15:43:39-04:00",
+      "updated_at": "2018-08-09T15:43:41-04:00",
+      "remote_reference": "1118367",
+      "payment_method": "credit_card",
+      "payment_details": {
+        "credit_card_number": "•••• •••• •••• 2",
+        "credit_card_company": "Bogus"
+      }
+    },
+    {
+      "id": 3,
+      "order_id": 450789469,
+      "amount": "28.16",
+      "currency": "CAD",
+      "user_id": null,
+      "test": true,
+      "processed_at": "2018-08-12T15:43:39-04:00",
+      "updated_at": "2018-08-09T15:43:41-04:00",
+      "remote_reference": "1118368",
+      "payment_method": "credit_card",
+      "payment_details": {
+        "credit_card_number": "•••• •••• •••• 3",
+        "credit_card_company": "Bogus"
+      }
+    }
+  ]
+}

--- a/test/tender_transaction_test.py
+++ b/test/tender_transaction_test.py
@@ -1,0 +1,12 @@
+import shopify
+from test.test_helper import TestCase
+
+class TenderTransactionTest(TestCase):
+    def setUp(self):
+        super(TenderTransactionTest, self).setUp()
+        self.fake("tender_transactions", method='GET', body=self.load_fixture('tender_transactions'))
+
+    def test_should_load_all_tender_transactions(self):
+        tender_transactions = shopify.TenderTransaction.find()
+        self.assertEqual(3, len(tender_transactions))
+        self.assertEqual([1, 2, 3], list(map(lambda t: t.id, tender_transactions)))


### PR DESCRIPTION
**Issue**: https://github.com/Shopify/money-transactions/issues/688

As we are preparing to launch the TenderTransaction api, we will need to make it available for use in our SDKs. This PR adds a new TenderTransaction resource as well as a json fixture.

This PR adds a TenderTransaction resource to the library, as well as a json fixture to be used for testing.