### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.2.0'
+VERSION = '4.0.0'


### PR DESCRIPTION
https://github.com/Shopify/shopify_python_api/pull/285 incorrectly bumped the version to 3.2.0 instead of 4.0.0.

Since we are deprecating some features (i.e. removing the `cancel()` method from RecurringApplicationCharge), semver dictates a major version bump.