### PR TITLE
Centralize all resource prefix definitions

### DIFF
--- a/shopify/base.py
+++ b/shopify/base.py
@@ -114,6 +114,23 @@ class ShopifyResourceMeta(ResourceMeta):
     format = property(get_format, set_format, None,
                       'Encoding used for request and responses')
 
+    def get_prefix_source(cls):
+        """Return the prefix source, by default derived from site."""
+        try:
+            return cls.override_prefix()
+        except AttributeError:
+            if hasattr(cls, '_prefix_source'):
+                return cls.site + cls._prefix_source
+            else:
+                return cls.site
+
+    def set_prefix_source(cls, value):
+        """Set the prefix source, which will be rendered into the prefix."""
+        cls._prefix_source = value
+
+    prefix_source = property(get_prefix_source, set_prefix_source, None,
+                             'prefix for lookups for this type of object.')
+
 
 @six.add_metaclass(ShopifyResourceMeta)
 class ShopifyResource(ActiveResource, mixins.Countable):

--- a/shopify/resources/access_scope.py
+++ b/shopify/resources/access_scope.py
@@ -2,4 +2,6 @@ from ..base import ShopifyResource
 
 
 class AccessScope(ShopifyResource):
-    _prefix_source = "/admin/oauth/"
+    @classmethod
+    def override_prefix(cls):
+        return "/admin/oauth"

--- a/shopify/resources/api_permission.py
+++ b/shopify/resources/api_permission.py
@@ -4,6 +4,6 @@ class ApiPermission(ShopifyResource):
 
     @classmethod
     def delete(cls):
-        cls.connection.delete('admin/api_permissions/current.' + cls.format.extension, cls.headers)
+        cls.connection.delete(cls.site + '/api_permissions/current.' + cls.format.extension, cls.headers)
 
     destroy = delete

--- a/shopify/resources/article.py
+++ b/shopify/resources/article.py
@@ -4,15 +4,15 @@ from .comment import Comment
 
 
 class Article(ShopifyResource, mixins.Metafields, mixins.Events):
-    _prefix_source = "/admin/blogs/$blog_id/"
+    _prefix_source = "/blogs/$blog_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         blog_id = options.get("blog_id")
         if blog_id:
-            return "/admin/blogs/%s" % (blog_id)
+            return "%s/blogs/%s" % (cls.site, blog_id)
         else:
-            return "/admin"
+            return cls.site
 
     def comments(self):
         return Comment.find(article_id=self.id)

--- a/shopify/resources/asset.py
+++ b/shopify/resources/asset.py
@@ -4,15 +4,15 @@ import base64
 
 class Asset(ShopifyResource):
     _primary_key = "key"
-    _prefix_source = "/admin/themes/$theme_id/"
+    _prefix_source = "/themes/$theme_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         theme_id = options.get("theme_id")
         if theme_id:
-            return "/admin/themes/%s" % theme_id
+            return "%s/themes/%s" % (cls.site, theme_id)
         else:
-            return "/admin"
+            return cls.site
 
     @classmethod
     def _element_path(cls, id, prefix_options={}, query_options=None):
@@ -34,7 +34,7 @@ class Asset(ShopifyResource):
         params = {"asset[key]": key}
         params.update(kwargs)
         theme_id = params.get("theme_id")
-        path_prefix = "/admin/themes/%s" % (theme_id) if theme_id else "/admin"
+        path_prefix = "%s/themes/%s" % (cls.site, theme_id) if theme_id else cls.site
 
         resource = cls.find_one("%s/assets.%s" % (path_prefix, cls.format.extension), **params)
 

--- a/shopify/resources/collection_publication.py
+++ b/shopify/resources/collection_publication.py
@@ -2,4 +2,4 @@ from ..base import ShopifyResource
 
 
 class CollectionPublication(ShopifyResource):
-    _prefix_source = "/admin/publications/$publication_id/"
+    _prefix_source = "/publications/$publication_id/"

--- a/shopify/resources/discount_code.py
+++ b/shopify/resources/discount_code.py
@@ -1,4 +1,4 @@
 from ..base import ShopifyResource
 
 class DiscountCode(ShopifyResource):
-    _prefix_source = "/admin/price_rules/$price_rule_id/"
+    _prefix_source = "/price_rules/$price_rule_id/"

--- a/shopify/resources/discount_code_creation.py
+++ b/shopify/resources/discount_code_creation.py
@@ -2,9 +2,11 @@ from ..base import ShopifyResource
 from .discount_code import DiscountCode
 
 class DiscountCodeCreation(ShopifyResource):
-    _prefix_source = "/admin/price_rules/$price_rule_id/"
+    _prefix_source = "/price_rules/$price_rule_id/"
 
     def discount_codes(self):
-        return DiscountCode.find(from_="/admin/price_rules/%s/batch/%s/discount_codes.%s" % (self._prefix_options['price_rule_id'],
-                                                                                             self.id,
-                                                                                             DiscountCodeCreation.format.extension))
+        return DiscountCode.find(from_="%s/price_rules/%s/batch/%s/discount_codes.%s" % (
+            ShopifyResource.site,
+            self._prefix_options['price_rule_id'],
+            self.id,
+            DiscountCodeCreation.format.extension))

--- a/shopify/resources/event.py
+++ b/shopify/resources/event.py
@@ -1,12 +1,12 @@
 from ..base import ShopifyResource
 
 class Event(ShopifyResource):
-    _prefix_source = "/admin/$resource/$resource_id/"
+    _prefix_source = "/$resource/$resource_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         resource = options.get("resource")
         if resource:
-            return "/admin/%s/%s" % (resource, options["resource_id"])
+            return "%s/s/%s" % (cls.site, resource, options["resource_id"])
         else:
-            return "/admin"
+            return cls.site

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -2,7 +2,7 @@ from ..base import ShopifyResource
 
 
 class Fulfillment(ShopifyResource):
-    _prefix_source = "/admin/orders/$order_id/"
+    _prefix_source = "/orders/$order_id/"
 
     def cancel(self):
         self._load_attributes_from_response(self.post("cancel"))

--- a/shopify/resources/image.py
+++ b/shopify/resources/image.py
@@ -6,15 +6,15 @@ import re
 
 
 class Image(ShopifyResource):
-    _prefix_source = "/admin/products/$product_id/"
+    _prefix_source = "/products/$product_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         product_id = options.get("product_id")
         if product_id:
-            return "/admin/products/%s" % (product_id)
+            return "%s/products/%s" % (cls.site, product_id)
         else:
-            return "/admin"
+            return cls.site
 
     def __getattr__(self, name):
         if name in ["pico", "icon", "thumb", "small", "compact", "medium", "large", "grande", "original"]:
@@ -31,7 +31,7 @@ class Image(ShopifyResource):
         if self.is_new():
             return []
         query_params = { 'metafield[owner_id]': self.id, 'metafield[owner_resource]': 'product_image' }
-        return Metafield.find(from_ = '/admin/metafields.json?%s' % urllib.parse.urlencode(query_params))
+        return Metafield.find(from_ = '%s/metafields.json?%s' % (ShopifyResource.site, urllib.parse.urlencode(query_params)))
 
     def save(self):
         if 'product_id' not in self._prefix_options:

--- a/shopify/resources/location.py
+++ b/shopify/resources/location.py
@@ -3,4 +3,5 @@ from .inventory_level import InventoryLevel
 
 class Location(ShopifyResource):
     def inventory_levels(self, **kwargs):
-        return InventoryLevel.find(from_="/admin/locations/%s/inventory_levels.json" % self.id, **kwargs)
+        return InventoryLevel.find(from_="%s/locations/%s/inventory_levels.json" % (
+            ShopifyResource.site, self.id), **kwargs)

--- a/shopify/resources/metafield.py
+++ b/shopify/resources/metafield.py
@@ -2,12 +2,12 @@ from ..base import ShopifyResource
 
 
 class Metafield(ShopifyResource):
-    _prefix_source = "/admin/$resource/$resource_id/"
+    _prefix_source = "/$resource/$resource_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         resource = options.get("resource")
         if resource:
-            return "/admin/%s/%s" % (resource, options["resource_id"])
+            return "%s/%s/%s" % (cls.site, resource, options["resource_id"])
         else:
-            return "/admin"
+            return cls.site

--- a/shopify/resources/order_risk.py
+++ b/shopify/resources/order_risk.py
@@ -1,6 +1,6 @@
 from ..base import ShopifyResource
 
 class OrderRisk(ShopifyResource):
-  _prefix_source = "/admin/orders/$order_id/"
+  _prefix_source = "/orders/$order_id/"
   _singular = "risk"
   _plural = "risks"

--- a/shopify/resources/price_rule.py
+++ b/shopify/resources/price_rule.py
@@ -18,5 +18,5 @@ class PriceRule(ShopifyResource):
         return DiscountCodeCreation(PriceRule.format.decode(response.body))
 
     def find_batch(self, batch_id):
-        return DiscountCodeCreation.find_one("admin/price_rules/%s/batch/%s.%s" % (self.id, batch_id,
-                                                                                   PriceRule.format.extension))
+        return DiscountCodeCreation.find_one("%s/price_rules/%s/batch/%s.%s" % (
+            ShopifyResource.site, self.id, batch_id, PriceRule.format.extension))

--- a/shopify/resources/product_publication.py
+++ b/shopify/resources/product_publication.py
@@ -2,4 +2,4 @@ from ..base import ShopifyResource
 
 
 class ProductPublication(ShopifyResource):
-    _prefix_source = "/admin/publications/$publication_id/"
+    _prefix_source = "/publications/$publication_id/"

--- a/shopify/resources/refund.py
+++ b/shopify/resources/refund.py
@@ -4,7 +4,7 @@ from ..base import ShopifyResource
 
 
 class Refund(ShopifyResource):
-    _prefix_source = "/admin/orders/$order_id/"
+    _prefix_source = "/orders/$order_id/"
 
     @classmethod
     def calculate(cls, order_id, shipping=None, refund_line_items=None):

--- a/shopify/resources/resource_feedback.py
+++ b/shopify/resources/resource_feedback.py
@@ -2,13 +2,13 @@ from ..base import ShopifyResource
 
 
 class ResourceFeedback(ShopifyResource):
-    _prefix_source = "/admin/products/$product_id/"
+    _prefix_source = "/products/$product_id/"
     _plural = "resource_feedback"
 
     @classmethod
     def _prefix(cls, options={}):
         product_id = options.get("product_id")
         if product_id:
-            return "/admin/products/%s" % product_id
+            return "%s/products/%s" % (cls.site, product_id)
         else:
-            return "/admin"
+            return cls.site

--- a/shopify/resources/shop.py
+++ b/shopify/resources/shop.py
@@ -7,7 +7,7 @@ class Shop(ShopifyResource):
 
     @classmethod
     def current(cls):
-        return cls.find_one("/admin/shop." + cls.format.extension)
+        return cls.find_one(cls.site + "/shop." + cls.format.extension)
 
     def metafields(self):
         return Metafield.find()

--- a/shopify/resources/transaction.py
+++ b/shopify/resources/transaction.py
@@ -2,4 +2,4 @@ from ..base import ShopifyResource
 
 
 class Transaction(ShopifyResource):
-    _prefix_source = "/admin/orders/$order_id/"
+    _prefix_source = "/orders/$order_id/"

--- a/shopify/resources/usage_charge.py
+++ b/shopify/resources/usage_charge.py
@@ -1,12 +1,12 @@
 from ..base import ShopifyResource
 
 class UsageCharge(ShopifyResource):
-    _prefix_source = "/admin/recurring_application_charge/$recurring_application_charge_id/"
+    _prefix_source = "/recurring_application_charge/$recurring_application_charge_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         recurring_application_charge_id = options.get("recurring_application_charge_id")
         if recurring_application_charge_id:
-            return "/admin/recurring_application_charges/%s" % (recurring_application_charge_id)
+            return "%s/recurring_application_charges/%s" % (cls.site, recurring_application_charge_id)
         else:
-            return "/admin"
+            return cls.site

--- a/shopify/resources/variant.py
+++ b/shopify/resources/variant.py
@@ -3,15 +3,15 @@ from shopify import mixins
 
 
 class Variant(ShopifyResource, mixins.Metafields):
-    _prefix_source = "/admin/products/$product_id/"
+    _prefix_source = "/products/$product_id/"
 
     @classmethod
     def _prefix(cls, options={}):
         product_id = options.get("product_id")
         if product_id:
-            return "/admin/products/%s" % (product_id)
+            return "%s/products/%s" % (cls.site, product_id)
         else:
-            return "/admin"
+            return cls.site
 
     def save(self):
         if 'product_id' not in self._prefix_options:


### PR DESCRIPTION
This PR removes all instances of `/admin` from all of the resource definitions and sets up a fallback to `Session.site` to prefix all requests.