### PR TITLE
Fixed 15 issues of type: PYTHON_E225 throughout 5 files in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
-NAME='ShopifyAPI'
+NAME = 'ShopifyAPI'
 exec(open('shopify/version.py').read())
-DESCRIPTION='Shopify API for Python'
-LONG_DESCRIPTION="""\
+DESCRIPTION = 'Shopify API for Python'
+LONG_DESCRIPTION = """\
 The ShopifyAPI library allows python developers to programmatically
 access the admin section of stores using an ActiveResource like
 interface similar the ruby Shopify API gem. The library makes HTTP

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -69,7 +69,7 @@ class BaseTest(TestCase):
     def test_delete_should_send_custom_headers_with_request(self):
         shopify.ShopifyResource.activate_session(self.session1)
 
-        org_headers=shopify.ShopifyResource.headers
+        org_headers = shopify.ShopifyResource.headers
         shopify.ShopifyResource.set_headers({'X-Custom': 'abc'})
 
         with patch('shopify.ShopifyResource.connection.delete') as mock:

--- a/test/draft_order_test.py
+++ b/test/draft_order_test.py
@@ -83,7 +83,7 @@ class DraftOrderTest(TestCase):
     def test_complete_draft_order_with_no_params(self):
         completed_fixture = self.load_fixture('draft_order_completed')
         completed_draft = json.loads(completed_fixture.decode("utf-8"))['draft_order']
-        headers={'Content-type': 'application/json', 'Content-length': '0'}
+        headers = {'Content-type': 'application/json', 'Content-length': '0'}
         self.fake('draft_orders/517119332/complete', method='PUT', body=completed_fixture, headers=headers)
         self.draft_order.complete()
         self.assertEqual(completed_draft['status'], self.draft_order.status)

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -137,7 +137,7 @@ class SessionTest(TestCase):
 
     def test_hmac_calculation(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
           'shop': 'some-shop.myshopify.com',
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
@@ -147,7 +147,7 @@ class SessionTest(TestCase):
         self.assertEqual(shopify.Session.calculate_hmac(params), params['hmac'])
 
     def test_hmac_calculation_with_ampersand_and_equal_sign_characters(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = { 'a': '1&b=2', 'c=3&d': '4' }
         to_sign = "a=1%26b=2&c%3D3%26d=4"
         expected_hmac = hmac.new('secret'.encode(), to_sign.encode(), sha256).hexdigest()
@@ -155,7 +155,7 @@ class SessionTest(TestCase):
 
     def test_hmac_validation(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
           'shop': 'some-shop.myshopify.com',
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
@@ -166,7 +166,7 @@ class SessionTest(TestCase):
 
     def test_parameter_validation_handles_missing_params(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
           'shop': 'some-shop.myshopify.com',
           'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
@@ -175,7 +175,7 @@ class SessionTest(TestCase):
         self.assertFalse(shopify.Session.validate_params(params))
 
     def test_param_validation_of_param_values_with_lists(self):
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
             'shop': 'some-shop.myshopify.com',
             'ids[]': [
@@ -187,7 +187,7 @@ class SessionTest(TestCase):
         self.assertEqual(True, shopify.Session.validate_hmac(params))
 
     def test_return_token_if_hmac_is_valid(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = {'code': 'any-code', 'timestamp': time.time()}
         hmac = shopify.Session.calculate_hmac(params)
         params['hmac'] = hmac
@@ -198,7 +198,7 @@ class SessionTest(TestCase):
         self.assertEqual("token", token)
 
     def test_raise_error_if_hmac_is_invalid(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = {'code': 'any-code', 'timestamp': time.time()}
         params['hmac'] = 'a94a110d86d2452e92a4a64275b128e9273be3037f2c339eb3e2af4cfb8a3828'
 
@@ -207,7 +207,7 @@ class SessionTest(TestCase):
             session = session.request_token(params)
 
     def test_raise_error_if_hmac_does_not_match_expected(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = {'foo': 'hello', 'timestamp': time.time()}
         hmac = shopify.Session.calculate_hmac(params)
         params['hmac'] = hmac
@@ -219,7 +219,7 @@ class SessionTest(TestCase):
             session = session.request_token(params)
 
     def test_raise_error_if_timestamp_is_too_old(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         one_day = 24 * 60 * 60
         params = {'code': 'any-code', 'timestamp': time.time()-(2*one_day)}
         hmac = shopify.Session.calculate_hmac(params)

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -9,7 +9,7 @@ class TestCase(unittest.TestCase):
 
     def setUp(self):
         ActiveResource.site = None
-        ActiveResource.headers=None
+        ActiveResource.headers = None
 
         shopify.ShopifyResource.clear_session()
         shopify.ShopifyResource.site = "https://this-is-my-test-show.myshopify.com/admin/api/unstable"


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.