### PR TITLE
Fixed 26 issues of type: PYTHON_E231 throughout 12 files in repo.

### DIFF
--- a/test/article_test.py
+++ b/test/article_test.py
@@ -5,7 +5,7 @@ class ArticleTest(TestCase):
 
     def test_create_article(self):
         self.fake("blogs/1008414260/articles", method='POST', body=self.load_fixture('article'), headers={'Content-type': 'application/json'})
-        article = shopify.Article({'blog_id':1008414260})
+        article = shopify.Article({'blog_id': 1008414260})
         article.save()
         self.assertEqual("First Post", article.title)
 

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -12,8 +12,8 @@ class FulFillmentTest(TestCase):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
         success = self.load_fixture('fulfillment')
-        success = success.replace(b'pending',b'open')
-        self.fake("orders/450789469/fulfillments/255858046/open", method='POST', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=success)
+        success = success.replace(b'pending', b'open')
+        self.fake("orders/450789469/fulfillments/255858046/open", method='POST', headers={'Content-length': '0', 'Content-type': 'application/json'}, body=success)
 
         self.assertEqual('pending', fulfillment.status)
         fulfillment.open()
@@ -23,8 +23,8 @@ class FulFillmentTest(TestCase):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
         success = self.load_fixture('fulfillment')
-        success = success.replace(b'pending',b'success')
-        self.fake("orders/450789469/fulfillments/255858046/complete", method='POST', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=success)
+        success = success.replace(b'pending', b'success')
+        self.fake("orders/450789469/fulfillments/255858046/complete", method='POST', headers={'Content-length': '0', 'Content-type': 'application/json'}, body=success)
 
         self.assertEqual('pending', fulfillment.status)
         fulfillment.complete()
@@ -35,7 +35,7 @@ class FulFillmentTest(TestCase):
 
         cancelled = self.load_fixture('fulfillment')
         cancelled = cancelled.replace(b'pending', b'cancelled')
-        self.fake("orders/450789469/fulfillments/255858046/cancel", method='POST', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=cancelled)
+        self.fake("orders/450789469/fulfillments/255858046/cancel", method='POST', headers={'Content-length': '0', 'Content-type': 'application/json'}, body=cancelled)
 
         self.assertEqual('pending', fulfillment.status)
         fulfillment.cancel()

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -6,7 +6,7 @@ class ImageTest(TestCase):
 
     def test_create_image(self):
         self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})
-        image = shopify.Image({'product_id':632910392})
+        image = shopify.Image({'product_id': 632910392})
         image.position = 1
         image.attachment = "R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf=="
         image.save()
@@ -16,7 +16,7 @@ class ImageTest(TestCase):
 
     def test_attach_image(self):
         self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})
-        image = shopify.Image({'product_id':632910392})
+        image = shopify.Image({'product_id': 632910392})
         image.position = 1
         binary_in = base64.b64decode("R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf==")
         image.attach_image(data=binary_in, filename='ipod-nano.png')

--- a/test/location_test.py
+++ b/test/location_test.py
@@ -6,16 +6,16 @@ class LocationTest(TestCase):
     def test_fetch_locations(self):
         self.fake("locations", method='GET', body=self.load_fixture('locations'))
         locations = shopify.Location.find()
-        self.assertEqual(2,len(locations))
+        self.assertEqual(2, len(locations))
 
     def test_fetch_location(self):
         self.fake("locations/487838322", method='GET', body=self.load_fixture('location'))
         location = shopify.Location.find(487838322)
-        self.assertEqual(location.id,487838322)
-        self.assertEqual(location.name,"Fifth Avenue AppleStore")
+        self.assertEqual(location.id, 487838322)
+        self.assertEqual(location.name, "Fifth Avenue AppleStore")
 
     def test_inventory_levels_returns_all_inventory_levels(self):
-        location = shopify.Location({'id':487838322})
+        location = shopify.Location({'id': 487838322})
 
         self.fake(
             "locations/%s/inventory_levels" % location.id,

--- a/test/order_risk_test.py
+++ b/test/order_risk_test.py
@@ -5,7 +5,7 @@ class OrderRiskTest(TestCase):
 
   def test_create_order_risk(self):
     self.fake("orders/450789469/risks", method='POST', body= self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
-    v = shopify.OrderRisk({'order_id':450789469})
+    v = shopify.OrderRisk({'order_id': 450789469})
     v.message = "This order was placed from a proxy IP"
     v.recommendation = "cancel"
     v.score = "1.0"

--- a/test/recurring_charge_test.py
+++ b/test/recurring_charge_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 class RecurringApplicationChargeTest(TestCase):
     def test_activate_charge(self):
         # Just check that calling activate doesn't raise an exception.
-        self.fake("recurring_application_charges/35463/activate", method='POST',headers={'Content-length':'0', 'Content-type': 'application/json'}, body=" ")
+        self.fake("recurring_application_charges/35463/activate", method='POST', headers={'Content-length': '0', 'Content-type': 'application/json'}, body=" ")
         charge = shopify.RecurringApplicationCharge({'id': 35463})
         charge.activate()
 
@@ -35,7 +35,7 @@ class RecurringApplicationChargeTest(TestCase):
         charge = shopify.RecurringApplicationCharge.current()
         self.assertEqual(charge.capped_amount, 100)
 
-        self.fake("recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200", extension=False, method='PUT', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=self.load_fixture('recurring_application_charge_adjustment'))
+        self.fake("recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200", extension=False, method='PUT', headers={'Content-length': '0', 'Content-type': 'application/json'}, body=self.load_fixture('recurring_application_charge_adjustment'))
         charge.customize(capped_amount= 200)
         self.assertTrue(charge.update_capped_amount_url)
 

--- a/test/resource_feedback_test.py
+++ b/test/resource_feedback_test.py
@@ -31,7 +31,7 @@ class ResourceFeedbackTest(TestCase):
         body = json.dumps({ 'resource_feedback': {} })
         self.fake('products/42/resource_feedback', method='POST', body=body, headers={ 'Content-Type': 'application/json' })
 
-        feedback = shopify.ResourceFeedback({'product_id':42})
+        feedback = shopify.ResourceFeedback({'product_id': 42})
         feedback.save()
 
         self.assertEqual(body, self.http.request.data.decode("utf-8"))

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -40,7 +40,7 @@ class SessionTest(TestCase):
     def test_raise_error_if_params_passed_but_signature_omitted(self):
         with self.assertRaises(shopify.ValidationException):
             session = shopify.Session("testshop.myshopify.com", 'unstable')
-            token = session.request_token({'code':'any_code', 'foo': 'bar', 'timestamp':'1234'})
+            token = session.request_token({'code': 'any_code', 'foo': 'bar', 'timestamp': '1234'})
 
     def test_setup_api_key_and_secret_for_all_sessions(self):
         shopify.Session.setup(api_key="My test key", secret="My test secret")
@@ -96,7 +96,7 @@ class SessionTest(TestCase):
     def test_create_permission_url_returns_correct_url_with_dual_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
-        scope = ["write_products","write_customers"]
+        scope = ["write_products", "write_customers"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
         self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products%2Cwrite_customers", self.normalize_url(permission_url))
 
@@ -127,7 +127,7 @@ class SessionTest(TestCase):
         self.fake(None, url='https://localhost.myshopify.com/admin/oauth/access_token', method='POST', code=404, body='{"error" : "invalid_request"}', has_user_agent=False)
 
         with self.assertRaises(shopify.ValidationException):
-            session.request_token({'code':'any-code', 'timestamp':'1234'})
+            session.request_token({'code': 'any-code', 'timestamp': '1234'})
 
         self.assertFalse(session.valid)
 

--- a/test/shipping_zone_test.py
+++ b/test/shipping_zone_test.py
@@ -5,7 +5,7 @@ class ShippingZoneTest(TestCase):
     def test_get_shipping_zones(self):
         self.fake("shipping_zones", method='GET', body=self.load_fixture('shipping_zones'))
         shipping_zones = shopify.ShippingZone.find()
-        self.assertEqual(1,len(shipping_zones))
-        self.assertEqual(shipping_zones[0].name,"Some zone")	
-        self.assertEqual(3,len(shipping_zones[0].countries))
+        self.assertEqual(1, len(shipping_zones))
+        self.assertEqual(shipping_zones[0].name, "Some zone")	
+        self.assertEqual(3, len(shipping_zones[0].countries))
 	

--- a/test/shop_test.py
+++ b/test/shop_test.py
@@ -8,7 +8,7 @@ class ShopTest(TestCase):
         self.shop = shopify.Shop.current()
 
     def test_current_should_return_current_shop(self):
-        self.assertTrue(isinstance(self.shop,shopify.Shop))
+        self.assertTrue(isinstance(self.shop, shopify.Shop))
         self.assertEqual("Apple Computers", self.shop.name)
         self.assertEqual("apple.myshopify.com", self.shop.myshopify_domain)
         self.assertEqual(690933842, self.shop.id)

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -27,8 +27,8 @@ class TestCase(unittest.TestCase):
 
     def fake(self, endpoint, **kwargs):
         body = kwargs.pop('body', None) or self.load_fixture(endpoint)
-        format = kwargs.pop('format','json')
-        method = kwargs.pop('method','GET')
+        format = kwargs.pop('format', 'json')
+        method = kwargs.pop('method', 'GET')
         prefix = kwargs.pop('prefix', '/admin/api/unstable')
 
         if ('extension' in kwargs and not kwargs['extension']):

--- a/test/variant_test.py
+++ b/test/variant_test.py
@@ -20,7 +20,7 @@ class VariantTest(TestCase):
 
     def test_create_variant(self):
         self.fake("products/632910392/variants", method='POST', body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
-        v = shopify.Variant({'product_id':632910392})
+        v = shopify.Variant({'product_id': 632910392})
         v.save()
 
     def test_create_variant_then_add_parent_id(self):


### PR DESCRIPTION
PYTHON_E231: 'missing whitespace after ‘,’, ‘;’, or ‘:’'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.