### PR TITLE
Fixed 24 issues of type: PYTHON_E251 throughout 15 files in repo.

### DIFF
--- a/shopify/resources/customer.py
+++ b/shopify/resources/customer.py
@@ -21,6 +21,6 @@ class Customer(ShopifyResource, mixins.Metafields):
         """
         return cls._build_list(cls.get("search", **kwargs))
 
-    def send_invite(self, customer_invite = CustomerInvite()):
+    def send_invite(self, customer_invite=CustomerInvite()):
         resource = self.post("send_invite", customer_invite.encode())
         return CustomerInvite(Customer.format.decode(resource.body))

--- a/shopify/resources/draft_order.py
+++ b/shopify/resources/draft_order.py
@@ -4,11 +4,11 @@ from .draft_order_invoice import DraftOrderInvoice
 
 
 class DraftOrder(ShopifyResource, mixins.Metafields):
-    def send_invoice(self, draft_order_invoice = DraftOrderInvoice()):
+    def send_invoice(self, draft_order_invoice=DraftOrderInvoice()):
         resource = self.post("send_invoice", draft_order_invoice.encode())
         return DraftOrderInvoice(DraftOrder.format.decode(resource.body))
 
-    def complete(self, params = {}):
+    def complete(self, params={}):
         if params.get('payment_pending', False):
           self._load_attributes_from_response(self.put("complete", payment_pending='true'))
         else:

--- a/shopify/resources/image.py
+++ b/shopify/resources/image.py
@@ -31,7 +31,7 @@ class Image(ShopifyResource):
         if self.is_new():
             return []
         query_params = { 'metafield[owner_id]': self.id, 'metafield[owner_resource]': 'product_image' }
-        return Metafield.find(from_ = '%s/metafields.json?%s' % (ShopifyResource.site, urllib.parse.urlencode(query_params)))
+        return Metafield.find(from_='%s/metafields.json?%s' % (ShopifyResource.site, urllib.parse.urlencode(query_params)))
 
     def save(self):
         if 'product_id' not in self._prefix_options:

--- a/shopify/resources/price_rule.py
+++ b/shopify/resources/price_rule.py
@@ -4,14 +4,14 @@ from .discount_code import DiscountCode
 from .discount_code_creation import DiscountCodeCreation
 
 class PriceRule(ShopifyResource):
-    def add_discount_code(self, discount_code = DiscountCode()):
+    def add_discount_code(self, discount_code=DiscountCode()):
         resource = self.post("discount_codes", discount_code.encode())
         return DiscountCode(PriceRule.format.decode(resource.body))
 
     def discount_codes(self):
         return DiscountCode.find(price_rule_id=self.id)
 
-    def create_batch(self, codes = []):
+    def create_batch(self, codes=[]):
         codes_json = json.dumps({ 'discount_codes': codes})
 
         response = self.post("batch", codes_json.encode())

--- a/shopify/resources/recurring_application_charge.py
+++ b/shopify/resources/recurring_application_charge.py
@@ -14,7 +14,7 @@ class RecurringApplicationCharge(ShopifyResource):
         return UsageCharge.find(recurring_application_charge_id=self.id)
 
     def customize(self, **kwargs):
-        self._load_attributes_from_response(self.put("customize", recurring_application_charge= kwargs))
+        self._load_attributes_from_response(self.put("customize", recurring_application_charge=kwargs))
 
     @classmethod
     def current(cls):

--- a/test/asset_test.py
+++ b/test/asset_test.py
@@ -22,7 +22,7 @@ class AssetTest(TestCase):
 
     def test_get_assets_namespaced(self):
         self.fake("themes/1/assets", method='GET', body=self.load_fixture('assets'))
-        v = shopify.Asset.find(theme_id = 1)
+        v = shopify.Asset.find(theme_id=1)
 
     def test_get_asset_namespaced(self):
         self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1", extension=False, method='GET', body=self.load_fixture('asset'))

--- a/test/collection_publication_test.py
+++ b/test/collection_publication_test.py
@@ -7,7 +7,7 @@ class CollectionPublicationTest(TestCase):
         self.fake(
             'publications/55650051/collection_publications',
             method='GET',
-            body= self.load_fixture('collection_publications')
+            body=self.load_fixture('collection_publications')
         )
         collection_publications = shopify.CollectionPublication.find(publication_id=55650051)
 

--- a/test/customer_saved_search_test.py
+++ b/test/customer_saved_search_test.py
@@ -14,7 +14,7 @@ class CustomerSavedSearchTest(TestCase):
 
     def test_get_customers_from_customer_saved_search_with_params(self):
         self.fake('customer_saved_searches/8899730/customers.json?limit=1', extension=False, body=self.load_fixture('customer_saved_search_customers'))
-        customers = self.customer_saved_search.customers(limit = 1)
+        customers = self.customer_saved_search.customers(limit=1)
         self.assertEqual(1, len(customers))
         self.assertEqual(112223902, customers[0].id)
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -52,7 +52,7 @@ class ImageTest(TestCase):
         fake_extension = 'json?metafield[owner_id]=850703190&metafield[owner_resource]=product_image'
         self.fake("metafields", method='GET', extension=fake_extension, body=self.load_fixture('image_metafields'))
 
-        image = shopify.Image(attributes = { 'id': 850703190, 'product_id': 632910392 })
+        image = shopify.Image(attributes={ 'id': 850703190, 'product_id': 632910392 })
         metafields = image.metafields()
 
         self.assertEqual(1, len(metafields))

--- a/test/order_risk_test.py
+++ b/test/order_risk_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 class OrderRiskTest(TestCase):
 
   def test_create_order_risk(self):
-    self.fake("orders/450789469/risks", method='POST', body= self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
+    self.fake("orders/450789469/risks", method='POST', body=self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
     v = shopify.OrderRisk({'order_id':450789469})
     v.message = "This order was placed from a proxy IP"
     v.recommendation = "cancel"
@@ -18,24 +18,24 @@ class OrderRiskTest(TestCase):
     self.assertEqual(284138680, v.id)
 
   def test_get_order_risks(self):
-    self.fake("orders/450789469/risks", method='GET', body= self.load_fixture('order_risks'))
+    self.fake("orders/450789469/risks", method='GET', body=self.load_fixture('order_risks'))
     v = shopify.OrderRisk.find(order_id=450789469)
     self.assertEqual(2, len(v))
 
   def test_get_order_risk(self):
-    self.fake("orders/450789469/risks/284138680", method='GET', body= self.load_fixture('order_risk'))
+    self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
     v = shopify.OrderRisk.find(284138680, order_id=450789469)
     self.assertEqual(284138680, v.id)
 
   def test_delete_order_risk(self):
-    self.fake("orders/450789469/risks/284138680", method='GET', body= self.load_fixture('order_risk'))
+    self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
     self.fake("orders/450789469/risks/284138680", method='DELETE', body="destroyed")
     v = shopify.OrderRisk.find(284138680, order_id=450789469)
     v.destroy()
 
   def test_delete_order_risk(self):
-    self.fake("orders/450789469/risks/284138680", method='GET', body= self.load_fixture('order_risk'))
-    self.fake("orders/450789469/risks/284138680", method='PUT', body= self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
+    self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
+    self.fake("orders/450789469/risks/284138680", method='PUT', body=self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
 
     v = shopify.OrderRisk.find(284138680, order_id=450789469)
     v.position = 3

--- a/test/product_listing_test.py
+++ b/test/product_listing_test.py
@@ -29,7 +29,7 @@ class ProductListingTest(TestCase):
         self.assertEqual("Synergistic Silk Chair", product_listing.title)
 
     def test_get_product_listing_product_ids(self):
-        self.fake('product_listings/product_ids', method='GET', status = 200, body=self.load_fixture('product_listing_product_ids'))
+        self.fake('product_listings/product_ids', method='GET', status=200, body=self.load_fixture('product_listing_product_ids'))
 
         product_ids = shopify.ProductListing.product_ids()
 

--- a/test/product_publication_test.py
+++ b/test/product_publication_test.py
@@ -7,7 +7,7 @@ class ProductPublicationTest(TestCase):
         self.fake(
             'publications/55650051/product_publications',
             method='GET',
-            body= self.load_fixture('product_publications')
+            body=self.load_fixture('product_publications')
         )
         product_publications = shopify.ProductPublication.find(publication_id=55650051)
 

--- a/test/recurring_charge_test.py
+++ b/test/recurring_charge_test.py
@@ -36,7 +36,7 @@ class RecurringApplicationChargeTest(TestCase):
         self.assertEqual(charge.capped_amount, 100)
 
         self.fake("recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200", extension=False, method='PUT', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=self.load_fixture('recurring_application_charge_adjustment'))
-        charge.customize(capped_amount= 200)
+        charge.customize(capped_amount=200)
         self.assertTrue(charge.update_capped_amount_url)
 
     def test_destroy_recurring_application_charge(self):

--- a/test/usage_charge_test.py
+++ b/test/usage_charge_test.py
@@ -12,5 +12,5 @@ class UsageChargeTest(TestCase):
     def test_get_usage_charge(self):
         self.fake("recurring_application_charges/654381177/usage_charges/359376002", method='GET', body=self.load_fixture('usage_charge'))
 
-        charge = shopify.UsageCharge.find(359376002, recurring_application_charge_id= 654381177)
+        charge = shopify.UsageCharge.find(359376002, recurring_application_charge_id=654381177)
         self.assertEqual('1000 emails', charge.description)

--- a/test/variant_test.py
+++ b/test/variant_test.py
@@ -5,15 +5,15 @@ class VariantTest(TestCase):
 
     def test_get_variants(self):
         self.fake("products/632910392/variants", method='GET', body=self.load_fixture('variants'))
-        v = shopify.Variant.find(product_id = 632910392)
+        v = shopify.Variant.find(product_id=632910392)
 
     def test_get_variant_namespaced(self):
         self.fake("products/632910392/variants/808950810", method='GET', body=self.load_fixture('variant'))
-        v = shopify.Variant.find(808950810, product_id = 632910392)
+        v = shopify.Variant.find(808950810, product_id=632910392)
 
     def test_update_variant_namespace(self):
         self.fake("products/632910392/variants/808950810", method='GET', body=self.load_fixture('variant'))
-        v = shopify.Variant.find(808950810, product_id = 632910392)
+        v = shopify.Variant.find(808950810, product_id=632910392)
 
         self.fake("products/632910392/variants/808950810", method='PUT', body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
         v.save()


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.