### PR TITLE
Fixed 1 issue of type: PYTHON_W291 throughout 1 file in repo.

### DIFF
--- a/test/shipping_zone_test.py
+++ b/test/shipping_zone_test.py
@@ -6,6 +6,6 @@ class ShippingZoneTest(TestCase):
         self.fake("shipping_zones", method='GET', body=self.load_fixture('shipping_zones'))
         shipping_zones = shopify.ShippingZone.find()
         self.assertEqual(1,len(shipping_zones))
-        self.assertEqual(shipping_zones[0].name,"Some zone")	
+        self.assertEqual(shipping_zones[0].name,"Some zone")
         self.assertEqual(3,len(shipping_zones[0].countries))
 	


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.