### PR TITLE
Fixed 8 issues of type: PYTHON_W293 throughout 7 files in repo.

### DIFF
--- a/test/blog_test.py
+++ b/test/blog_test.py
@@ -2,7 +2,7 @@ import shopify
 from test.test_helper import TestCase
 
 class BlogTest(TestCase):
-    
+
     def test_blog_creation(self):
         self.fake('blogs', method='POST', code=202, body=self.load_fixture('blog'), headers={'Content-type': 'application/json'})
         blog = shopify.Blog.create({'title': "Test Blog"})

--- a/test/cart_test.py
+++ b/test/cart_test.py
@@ -2,7 +2,7 @@ import shopify
 from test.test_helper import TestCase
 
 class CartTest(TestCase):
-  
+
   def test_all_should_return_all_carts(self):
     self.fake('carts')
     carts = shopify.Cart.find()

--- a/test/checkout_test.py
+++ b/test/checkout_test.py
@@ -2,7 +2,7 @@ import shopify
 from test.test_helper import TestCase
 
 class CheckoutTest(TestCase):
-  
+
   def test_all_should_return_all_checkouts(self):
     self.fake('checkouts')
     checkouts = shopify.Checkout.find()

--- a/test/customer_saved_search_test.py
+++ b/test/customer_saved_search_test.py
@@ -2,7 +2,7 @@ import shopify
 from test.test_helper import TestCase
 
 class CustomerSavedSearchTest(TestCase):
-    
+
     def setUp(self):
         super(CustomerSavedSearchTest, self).setUp()
         self.load_customer_saved_search()

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -3,7 +3,7 @@ from test.test_helper import TestCase
 from pyactiveresource.activeresource import ActiveResource
 
 class FulFillmentTest(TestCase):
-  
+
     def setUp(self):
         super(FulFillmentTest, self).setUp()
         self.fake("orders/450789469/fulfillments/255858046", method='GET', body=self.load_fixture('fulfillment'))
@@ -29,7 +29,7 @@ class FulFillmentTest(TestCase):
         self.assertEqual('pending', fulfillment.status)
         fulfillment.complete()
         self.assertEqual('success', fulfillment.status)
-    
+
     def test_able_to_cancel_fulfillment(self):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 

--- a/test/shipping_zone_test.py
+++ b/test/shipping_zone_test.py
@@ -8,4 +8,4 @@ class ShippingZoneTest(TestCase):
         self.assertEqual(1,len(shipping_zones))
         self.assertEqual(shipping_zones[0].name,"Some zone")	
         self.assertEqual(3,len(shipping_zones[0].countries))
-	
+

--- a/test/variant_test.py
+++ b/test/variant_test.py
@@ -28,7 +28,7 @@ class VariantTest(TestCase):
         v = shopify.Variant()
         v.product_id = 632910392
         v.save()
-        
+
     def test_get_variant(self):
         self.fake("variants/808950810", method='GET', body=self.load_fixture('variant'))
         v = shopify.Variant.find(808950810)


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.