### PR TITLE
Fixed 4 issues of type: PYTHON_W391 throughout 4 files in repo.

### DIFF
--- a/test/api_version_test.py
+++ b/test/api_version_test.py
@@ -42,4 +42,3 @@ class ReleaseTest(TestCase):
         version1 = shopify.Release('2019-01')
         version2 = shopify.Release('2019-01')
         self.assertEqual(version1, version2)
-

--- a/test/currency_test.py
+++ b/test/currency_test.py
@@ -20,4 +20,3 @@ class CurrencyTest(TestCase):
         self.assertEqual("HKD", currencies[3].currency)
         self.assertEqual("2018-10-03T14:44:08-04:00", currencies[3].rate_updated_at)
         self.assertEqual(False, currencies[3].enabled)
-

--- a/test/discount_code_test.py
+++ b/test/discount_code_test.py
@@ -28,6 +28,3 @@ class DiscountCodeTest(TestCase):
       self.fake('price_rules/1213131/discount_codes/34', method='DELETE', body='destroyed')
       self.discount_code.destroy()
       self.assertEqual('DELETE', self.http.request.get_method())
-
-
-

--- a/test/shipping_zone_test.py
+++ b/test/shipping_zone_test.py
@@ -8,4 +8,3 @@ class ShippingZoneTest(TestCase):
         self.assertEqual(1,len(shipping_zones))
         self.assertEqual(shipping_zones[0].name,"Some zone")	
         self.assertEqual(3,len(shipping_zones[0].countries))
-	


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.