### PR TITLE
fix missing class var on ShopifyResource

### DIFF
--- a/shopify/base.py
+++ b/shopify/base.py
@@ -166,6 +166,7 @@ class ShopifyResource(ActiveResource, mixins.Countable):
     _threadlocal = threading.local()
     _headers = {'User-Agent': 'ShopifyPythonAPI/%s Python/%s' % (shopify.VERSION, sys.version.split(' ', 1)[0])}
     _version = None
+    _url = None
 
     def __init__(self, attributes=None, prefix_options=None):
         if attributes is not None and prefix_options is None:

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -97,3 +97,14 @@ class BaseTest(TestCase):
         t2 = threading.Thread(target=lambda: self.assertFalse('X-Custom' in shopify.ShopifyResource.headers))
         t2.start()
         t2.join()
+
+    def test_setting_site_without_token(self):
+        self.fake(
+            'shop',
+            url='https://user:pass@this-is-my-test-show.myshopify.com/admin/api/unstable/shop.json',
+            method='GET',
+            body=self.load_fixture('shop'),
+            headers={'Authorization': u'Basic dXNlcjpwYXNz'}
+        )
+        shopify.ShopifyResource.set_site('https://user:pass@this-is-my-test-show.myshopify.com/admin/api/unstable')
+        res = shopify.Shop.current()


### PR DESCRIPTION
Adds a missing class var to fix setting site with basic authentication. Closes #311 

@radovansurlak @bputt @muad-dweeb @kayluhb