### PR TITLE
Add GraphQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== Version 5.1.0
+* Added support for GraphQL queries
+
 == Version 5.0.1
 * Fixing missing class variable causing exception when creating a session without a token
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,24 @@ open up an interactive console to use the API with a shop.
     shopify_api.py help
     ```
 
+### GraphQL
+
+This library also supports Shopify's new [GraphQL API](https://help.shopify.com/en/api/graphql-admin-api) via a dependency on the [python-graphql-client](https://github.com/prisma/python-graphql-client) library. The authentication process (steps 1-5 under Getting Started) is identical. Once your session is activated, simply construct a new graphql client and use `execute` to execute the query.
+
+```
+client = shopify.GraphQL()
+  query = '''
+    {
+      shop {
+        name
+        id
+      }
+    }
+  '''
+  result = client.execute(query)
+```
+
+
 ## Using Development Version
 
 The development version can be built using

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ open up an interactive console to use the API with a shop.
 
 ### GraphQL
 
-This library also supports Shopify's new [GraphQL API](https://help.shopify.com/en/api/graphql-admin-api) via a dependency on the [python-graphql-client](https://github.com/prisma/python-graphql-client) library. The authentication process (steps 1-5 under Getting Started) is identical. Once your session is activated, simply construct a new graphql client and use `execute` to execute the query.
+This library also supports Shopify's new [GraphQL API](https://help.shopify.com/en/api/graphql-admin-api). The authentication process (steps 1-5 under Getting Started) is identical. Once your session is activated, simply construct a new graphql client and use `execute` to execute the query.
 
 ```
 client = shopify.GraphQL()

--- a/shopify/resources/__init__.py
+++ b/shopify/resources/__init__.py
@@ -71,5 +71,6 @@ from .api_permission import ApiPermission
 from .publication import Publication
 from .collection_publication import CollectionPublication
 from .product_publication import ProductPublication
+from .graphql import GraphQL
 
 from ..base import ShopifyResource

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -1,0 +1,15 @@
+from ..base import ShopifyResource
+from graphqlclient import GraphQLClient
+import ast
+
+class GraphQL(ShopifyResource):
+
+    @classmethod
+    def execute(cls, query):
+        client = GraphQLClient(cls.site + "/graphql.json")
+        client.inject_token(
+            cls.headers['X-Shopify-Access-Token'], 
+            'X-Shopify-Access-Token'
+        )
+        result = client.execute(query)
+        return ast.literal_eval(result)

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -1,15 +1,33 @@
+import shopify
 from ..base import ShopifyResource
-from graphqlclient import GraphQLClient
-import ast
+from six.moves import urllib
+import json
 
-class GraphQL(ShopifyResource):
+class GraphQL():
 
-    @classmethod
-    def execute(cls, query):
-        client = GraphQLClient(cls.site + "/graphql.json")
-        client.inject_token(
-            cls.headers['X-Shopify-Access-Token'], 
-            'X-Shopify-Access-Token'
-        )
-        result = client.execute(query)
-        return ast.literal_eval(result)
+    def __init__(self):
+        self.endpoint = (shopify.ShopifyResource.get_site() + "/graphql.json")
+        self.headers = shopify.ShopifyResource.get_headers()
+
+    def merge_headers(self, *headers):
+        merged_headers = {}
+        for header in headers:
+            merged_headers.update(header)
+        return merged_headers
+
+    def execute(self, query, variables=None):
+        endpoint = self.endpoint
+        default_headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        headers = self.merge_headers(default_headers, self.headers)
+        data = {'query': query,
+                'variables': variables}
+
+        req = urllib.request.Request(self.endpoint, json.dumps(data).encode('utf-8'), headers)
+
+        try:
+            response = urllib.request.urlopen(req)
+            return response.read().decode('utf-8')
+        except urllib.error.HTTPError as e:
+            print((e.read()))
+            print('')
+            raise e

--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = '5.0.1'
+VERSION = '5.1.0'

--- a/test/fixtures/graphql.json
+++ b/test/fixtures/graphql.json
@@ -1,0 +1,27 @@
+{
+  "shop": {
+    "name": "Apple Computers",
+    "city": "Cupertino",
+    "address1": "1 Infinite Loop",
+    "zip": "95014",
+    "created_at": "2007-12-31T19:00:00-05:00",
+    "shop_owner": "Steve Jobs",
+    "plan_name": "enterprise",
+    "public": false,
+    "country": "US",
+    "money_with_currency_format": "$ {{amount}} USD",
+    "money_format": "$ {{amount}}",
+    "domain": "shop.apple.com",
+    "taxes_included": null,
+    "id": 690933842,
+    "timezone": "(GMT-05:00) Eastern Time (US & Canada)",
+    "tax_shipping": null,
+    "phone": null,
+    "currency": "USD",
+    "myshopify_domain": "apple.myshopify.com",
+    "source": null,
+    "province": "CA",
+    "email": "steve@apple.com"
+  }
+}
+

--- a/test/graphql_test.py
+++ b/test/graphql_test.py
@@ -1,0 +1,34 @@
+import shopify
+import json
+from test.test_helper import TestCase
+
+class GraphQLTest(TestCase):
+
+    def setUp(self):
+        super(GraphQLTest, self).setUp()
+        shopify.ApiVersion.define_known_versions()
+        shopify_session = shopify.Session('this-is-my-test-show.myshopify.com', 'unstable', 'token')
+        shopify.ShopifyResource.activate_session(shopify_session)
+        client = shopify.GraphQL()
+        self.fake(
+            'graphql', 
+            method='POST', 
+            code=201, 
+            headers={
+                'X-Shopify-Access-Token': 'token',
+                'Accept': 'application/json', 
+                'Content-Type': 'application/json'
+                })
+        query = '''
+            {
+                shop {
+                    name
+                    id
+                }
+            }
+        '''
+        self.result = client.execute(query)
+
+
+    def test_fetch_shop_with_graphql(self):
+        self.assertTrue(json.loads(self.result)['shop']['name'] == 'Apple Computers')


### PR DESCRIPTION
Adds the ability to make GraphQL queries by supplying a query, as documented below. This follows the pattern that we established in Ruby. The test isn't great, we need to add something more robust for GraphQL at some point.

### GraphQL

 This library also supports Shopify's new [GraphQL API](https://help.shopify.com/en/api/graphql-admin-api). The authentication process (steps 1-5 under Getting Started) is identical. Once your session is activated, simply construct a new graphql client and use `execute` to execute the query.

 ```
client = shopify.GraphQL()
  query = '''
    {
      shop {
        name
        id
      }
    }
  '''
  result = client.execute(query)
```