### PR TITLE
Fix setting site with basic auth URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,17 @@ service. pyactiveresource has to be configured with a fully authorized
 URL of a particular store first. To obtain that URL you can follow
 these steps:
 
-1.  First create a new application in either the partners admin or
-    your store admin. For a private App you'll need the API_KEY and
-    the PASSWORD otherwise you'll need the API_KEY and SHARED_SECRET.
+1.  First create a new application in either the partners admin or your store
+    admin. You will need an API_VERSION equal to a valid version string of a
+    [Shopify API Version](https://help.shopify.com/en/api/versioning). For a
+    private App you'll need the API_KEY and the PASSWORD otherwise you'll need
+    the API_KEY and SHARED_SECRET.
 
 2.  For a private App you just need to set the base site url as
     follows:
 
      ```python
-     shop_url = "https://%s:%s@SHOP_NAME.myshopify.com/admin" % (API_KEY, PASSWORD)
+     shop_url = "https://%s:%s@SHOP_NAME.myshopify.com/admin/api/%s" % (API_KEY, PASSWORD, API_VERSION)
      shopify.ShopifyResource.set_site(shop_url)
      ```
 

--- a/shopify/base.py
+++ b/shopify/base.py
@@ -77,6 +77,11 @@ class ShopifyResourceMeta(ResourceMeta):
         ShopifyResource._site = cls._threadlocal.site = value
         if value is not None:
             parts = urllib.parse.urlparse(value)
+            host = parts.hostname
+            if parts.port:
+                host += ":" + str(parts.port)
+            new_site = urllib.parse.urlunparse((parts.scheme, host, parts.path, '', '', ''))
+            ShopifyResource._site = cls._threadlocal.site = new_site
             if parts.username:
                 cls.user = urllib.parse.unquote(parts.username)
             if parts.password:

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -98,13 +98,18 @@ class BaseTest(TestCase):
         t2.start()
         t2.join()
 
-    def test_setting_site_without_token(self):
+    def test_setting_with_user_and_pass_strips_them(self):
+        shopify.ShopifyResource.clear_session()
         self.fake(
             'shop',
-            url='https://user:pass@this-is-my-test-show.myshopify.com/admin/api/unstable/shop.json',
+            url='https://this-is-my-test-show.myshopify.com/admin/shop.json',
             method='GET',
             body=self.load_fixture('shop'),
             headers={'Authorization': u'Basic dXNlcjpwYXNz'}
         )
-        shopify.ShopifyResource.set_site('https://user:pass@this-is-my-test-show.myshopify.com/admin/api/unstable')
+        API_KEY = 'user'
+        PASSWORD = 'pass'
+        shop_url = "https://%s:%s@this-is-my-test-show.myshopify.com/admin" % (API_KEY, PASSWORD)
+        shopify.ShopifyResource.set_site(shop_url)
         res = shopify.Shop.current()
+        self.assertEqual('Apple Computers', res.name)

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -84,7 +84,7 @@ class SessionTest(TestCase):
             assigned_site = shopify.ShopifyResource.site
 
         self.assertEqual('https://testshop.myshopify.com/admin/api/unstable', assigned_site)
-        self.assertEqual('https://None/admin/api/unstable', shopify.ShopifyResource.site)
+        self.assertEqual('https://none/admin/api/unstable', shopify.ShopifyResource.site)
 
     def test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")


### PR DESCRIPTION
Fixes #314 

Currently in the README we tell users that are using this library with private app credentials (basic auth) to use the `set_site` method to set their session URL. This method blindly sets the `site` class attribute and is referenced by some resource definitions like [Shop](https://github.com/Shopify/shopify_python_api/blob/master/shopify/resources/shop.py#L10), which results in incorrect URLs being requested. Ideally resources shouldn't have to care about the FQDN/site url when generating code for API Requests, but that's out of scope of this fix.

This fix strips out the `username:password` fragment from the site URL like [the underlying pyactiveresource method](https://github.com/Shopify/pyactiveresource/blob/master/pyactiveresource/connection.py#L218-L233) but retains the path, which we need to keep because its our reference to the API version. Now `ShopifyResource.site` `connection.site` and threaded sites are all equivalent.