### PR TITLE
Implement cursor pagination

### DIFF
--- a/shopify/__init__.py
+++ b/shopify/__init__.py
@@ -3,3 +3,4 @@ from shopify.session import Session, ValidationException
 from shopify.resources import *
 from shopify.limits import Limits
 from shopify.api_version import *
+from shopify.collection import PaginatedIterator

--- a/shopify/base.py
+++ b/shopify/base.py
@@ -9,6 +9,7 @@ from six.moves import urllib
 import six
 
 from shopify.collection import PaginatedCollection
+from pyactiveresource.collection import Collection
 
 # Store the response from the last request in the connection object
 class ShopifyConnection(pyactiveresource.connection.Connection):
@@ -213,7 +214,8 @@ class ShopifyResource(ActiveResource, mixins.Countable):
 
         # pyactiveresource currently sends all headers from the response with
         # the collection.
-        if "headers" in collection.metadata:
+        if isinstance(collection, Collection) and \
+           "headers" in collection.metadata:
             headers = collection.metadata["headers"]
             if "Link" in headers:
                 pagination = cls._parse_pagination(headers["Link"])

--- a/shopify/base.py
+++ b/shopify/base.py
@@ -8,6 +8,7 @@ import sys
 from six.moves import urllib
 import six
 
+from shopify.collection import PaginatedCollection
 
 # Store the response from the last request in the connection object
 class ShopifyConnection(pyactiveresource.connection.Connection):
@@ -202,3 +203,46 @@ class ShopifyResource(ActiveResource, mixins.Countable):
         cls.password = None
         cls.version = None
         cls.headers.pop('X-Shopify-Access-Token', None)
+
+    @classmethod
+    def find(cls, id_=None, from_=None, **kwargs):
+        """Checks the resulting collection for pagination metadata."""
+
+        collection = super(ShopifyResource, cls).find(id_=id_, from_=from_,
+                                                      **kwargs)
+
+        # pyactiveresource currently sends all headers from the response with
+        # the collection.
+        if "headers" in collection.metadata:
+            headers = collection.metadata["headers"]
+            if "Link" in headers:
+                pagination = cls._parse_pagination(headers["Link"])
+                return PaginatedCollection(collection, metadata={
+                    "pagination": pagination,
+                    "resource_class": cls
+                })
+
+        return collection
+
+    @classmethod
+    def _parse_pagination(cls, data):
+        """Parses a Link header into a dict for cursor-based pagination.
+
+        Args:
+            data: The Link header value as a string.
+        Returns:
+            A dict with rel names as keys and URLs as values.
+        """
+
+        # Example Link header:
+        # <https://xxx.shopify.com/admin/...>; rel="previous",
+        # <https://xxx.shopify.com/admin/...>; rel="next"
+
+        values = data.split(", ")
+
+        result = {}
+        for value in values:
+            link, rel = value.split("; ")
+            result[rel.split('"')[1]] = link[1:-1]
+
+        return result

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -47,10 +47,11 @@ class PaginatedCollection(Collection):
             k: v[0] for k, v in query_dict.items()
         }
 
-    def previous(self, **extra_params):
+    def previous(self, no_cache=False, **extra_params):
         """Returns the previous page of items.
 
         Args:
+            no_cache: If true the page will not be cached.
             extra_params: Any extra parameters passed to find().
         Returns:
             A PaginatedCollection object with the new data set.
@@ -67,14 +68,18 @@ class PaginatedCollection(Collection):
         Resource = self.metadata["resource_class"]
         query_params = self._get_query_params(pagination["previous"])
         query_params.update(extra_params)
-        self._previous = Resource.find(id_=None, from_=None, **query_params)
-        self._previous._next = self
-        return self._previous
 
-    def next(self, **extra_params):
+        previous = Resource.find(id_=None, from_=None, **query_params)
+        if not no_cache:
+            self._previous = previous
+            self._previous._next = self
+        return previous
+
+    def next(self, no_cache=False, **extra_params):
         """Returns the next page of items.
 
         Args:
+            no_cache: If true the page will not be cached.
             extra_params: Any extra parameters passed to find().
         Returns:
             A PaginatedCollection object with the new data set.
@@ -91,9 +96,13 @@ class PaginatedCollection(Collection):
         Resource = self.metadata["resource_class"]
         query_params = self._get_query_params(pagination["next"])
         query_params.update(extra_params)
-        self._next = Resource.find(id_=None, from_=None, **query_params)
-        self._next._previous = self
-        return self._next
+
+        next = Resource.find(id_=None, from_=None, **query_params)
+        if not no_cache:
+            self._next = next
+            self._next._previous = self
+
+        return next
 
     def __iter__(self):
         """Iterates through all items, also fetching other pages."""

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -68,6 +68,7 @@ class PaginatedCollection(Collection):
         query_params = self._get_query_params(pagination["previous"])
         query_params.update(extra_params)
         self._previous = Resource.find(id_=None, from_=None, **query_params)
+        self._previous._next = self
         return self._previous
 
     def next(self, **extra_params):
@@ -91,6 +92,7 @@ class PaginatedCollection(Collection):
         query_params = self._get_query_params(pagination["next"])
         query_params.update(extra_params)
         self._next = Resource.find(id_=None, from_=None, **query_params)
+        self._next._previous = self
         return self._next
 
     def __iter__(self):

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -148,12 +148,13 @@ class PaginatedIterator(object):
     # every page and the page items are iterated
     """
 
-    def __init__(self, collection):
+    def __init__(self, collection, **extra_params):
         if not isinstance(collection, PaginatedCollection):
             raise TypeError("PaginatedIterator expects a PaginatedCollection "
                             "instance")
         self.collection = collection
         self.collection._no_iter_next = True
+        self.extra_params = extra_params
 
     def __iter__(self):
         """Iterate over pages, returning one page at a time."""
@@ -163,6 +164,7 @@ class PaginatedIterator(object):
             yield current_page
 
             try:
-                current_page = current_page.next(no_cache=True)
+                current_page = current_page.next(no_cache=True,
+                                                 **self.extra_params)
             except IndexError:
                 return

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -111,7 +111,8 @@ class PaginatedCollection(Collection):
 
     def __iter__(self):
         """Iterates through all items, also fetching other pages."""
-        yield from super(PaginatedCollection, self).__iter__()
+        for item in super(PaginatedCollection, self).__iter__():
+            yield item
 
         if self._no_iter_next:
             return
@@ -120,7 +121,9 @@ class PaginatedCollection(Collection):
             if not self._current_iter:
                 self._current_iter = self
             self._current_iter = self.next()
-            yield from self._current_iter
+
+            for item in self._current_iter:
+                yield item
         except IndexError:
             return
 

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -1,0 +1,82 @@
+from pyactiveresource.collection import Collection
+
+from six.moves.urllib.parse import urlparse, parse_qs
+
+class PaginatedCollection(Collection):
+    """
+    A subclass of Collection which allows cycling through pages of
+    data through cursor-based pagination.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """If given a Collection object as an argument, inherit its metadata."""
+
+        metadata = kwargs.pop("metadata", None)
+        obj = args[0]
+        if isinstance(obj, Collection):
+            if metadata:
+                metadata.update(obj.metadata)
+            else:
+                metadata = obj.metadata
+            super(PaginatedCollection, self).__init__(obj, metadata=metadata)
+        else:
+            super(PaginatedCollection, self).__init__(metadata=metadata or {},
+                                                      *args, **kwargs)
+
+    def _check_pagination_metadata(self):
+        if not ("pagination" in self.metadata
+                and "resource_class" in self.metadata):
+            raise AttributeError("Cursor-based pagination requires "
+                                 "\"pagination\" and \"resource_class\" "
+                                 "attributes in the metadata.")
+
+    def _get_query_params(self, url):
+        """Returns a dictionary of query arguments for the given URL."""
+        parsed_url = urlparse(url)
+        query_dict = parse_qs(parsed_url.query)
+
+        # pyactiveresource.util.to_query considers list items to be multiple
+        # query items and so appends a [] to them which is wrong, because it
+        # fails to consider lists with a length of 1 (which is always returned
+        # from parse_qs). We need to flatten the items.
+        return {
+            k: v[0] for k, v in query_dict.items()
+        }
+
+    def previous(self, **extra_params):
+        """Returns the previous page of items.
+
+        Args:
+            extra_params: Any extra parameters passed to find().
+        Returns:
+            A PaginatedCollection object with the new data set.
+        """
+        self._check_pagination_metadata()
+
+        pagination = self.metadata["pagination"]
+        if not "previous" in pagination:
+            raise IndexError("No previous page")
+
+        Resource = self.metadata["resource_class"]
+        query_params = self._get_query_params(pagination["previous"])
+        query_params.update(extra_params)
+        return Resource.find(id_=None, from_=None, **query_params)
+
+    def next(self, **extra_params):
+        """Returns the next page of items.
+
+        Args:
+            extra_params: Any extra parameters passed to find().
+        Returns:
+            A PaginatedCollection object with the new data set.
+        """
+        self._check_pagination_metadata()
+
+        pagination = self.metadata["pagination"]
+        if not "next" in pagination:
+            raise IndexError("No next page")
+
+        Resource = self.metadata["resource_class"]
+        query_params = self._get_query_params(pagination["next"])
+        query_params.update(extra_params)
+        return Resource.find(id_=None, from_=None, **query_params)

--- a/shopify/resources/customer.py
+++ b/shopify/resources/customer.py
@@ -17,9 +17,9 @@ class Customer(ShopifyResource, mixins.Metafields):
            limit: Amount of results (default: 50) (maximum: 250)
            fields: comma-seperated list of fields to include in the response
         Returns:
-           An array of customers.
+           A Collection of customers.
         """
-        return cls._build_list(cls.get("search", **kwargs))
+        return cls._build_collection(cls.get("search", **kwargs))
 
     def send_invite(self, customer_invite = CustomerInvite()):
         resource = self.post("send_invite", customer_invite.encode())

--- a/shopify/resources/customer_saved_search.py
+++ b/shopify/resources/customer_saved_search.py
@@ -5,4 +5,4 @@ from .customer import Customer
 class CustomerSavedSearch(ShopifyResource):
 
     def customers(cls, **kwargs):
-        return Customer._build_list(cls.get("customers", **kwargs))
+        return Customer._build_collection(cls.get("customers", **kwargs))

--- a/test/fixtures/products.json
+++ b/test/fixtures/products.json
@@ -1,0 +1,206 @@
+[
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 1,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 1,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  },
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 2,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 2,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 2,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  },
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 3,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 2,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 2,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  },
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 4,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 4,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 4,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  }
+]

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -74,3 +74,14 @@ class CollectionTest(TestCase):
 
         with self.assertRaises(IndexError, msg="previous() did not raise with no previous page"):
             p.previous()
+
+    def test_paginated_collection_iterator(self):
+        c = shopify.Product.find()
+
+        i = iter(c)
+        self.assertEqual(next(i).id, 1)
+        self.assertEqual(next(i).id, 2)
+        self.assertEqual(next(i).id, 3)
+        self.assertEqual(next(i).id, 4)
+        with self.assertRaises(StopIteration):
+            next(i)

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -2,10 +2,10 @@ import shopify
 import json
 from test.test_helper import TestCase
 
-class CollectionTest(TestCase):
+class PaginationTest(TestCase):
 
     def setUp(self):
-        super(CollectionTest, self).setUp()
+        super(PaginationTest, self).setUp()
 
         fixture = json.loads(self.load_fixture('products'))
 

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -1,0 +1,76 @@
+import shopify
+import json
+from test.test_helper import TestCase
+
+class CollectionTest(TestCase):
+
+    def setUp(self):
+        super(CollectionTest, self).setUp()
+
+        fixture = json.loads(self.load_fixture('products'))
+
+        # Assumes limit is 2
+        prefix = self.http.site + "/admin/api/unstable"
+
+        next_headers = {
+            "Link": "<" + prefix + "/products.json?limit=2&page_info="
+            "FOOBAR>; rel=\"next\""
+        }
+        next_body = json.dumps({ "products": fixture[:2] })
+
+        self.fake("products",
+                  url=prefix + "/products.json",
+                  body=next_body,
+                  response_headers=next_headers)
+        self.fake("products",
+                  url=prefix + "/products.json?limit=2&page_info=BAZQUUX",
+                  body=next_body,
+                  response_headers=next_headers)
+        self.fake("products",
+                  url=prefix + "/products.json?limit=2&page_info=FOOBAR",
+                  body=json.dumps({ "products": fixture[2:] }),
+                  response_headers={
+                      "Link": "<" + prefix + "/products.json?limit=2&page_info="
+                      "BAZQUUX>; rel=\"previous\""
+                  })
+
+
+    def test_paginated_collection(self):
+        items = shopify.Product.find()
+
+        self.assertIsInstance(items, shopify.collection.PaginatedCollection,
+                              "find() result is not PaginatedCollection")
+        self.assertEqual(len(items), 2,
+                         "find() result has incorrect length")
+
+    def test_pagination_next(self):
+        c = shopify.Product.find()
+
+        n = c.next()
+        self.assertIsInstance(n, shopify.collection.PaginatedCollection,
+                              "next() result is not PaginatedCollection")
+        self.assertEqual(len(n), 2,
+                         "next() collection has incorrect length")
+        self.assertIn("pagination", n.metadata)
+        self.assertIn("previous", n.metadata["pagination"],
+                      "next() collection doesn't have a previous page")
+
+        with self.assertRaises(IndexError, msg="next() did not raise with no next page"):
+            n.next()
+
+    def test_pagination_previous(self):
+        c = shopify.Product.find()
+        n = c.next()
+
+        p = n.previous()
+
+        self.assertIsInstance(p, shopify.collection.PaginatedCollection,
+                              "previous() result is not PaginatedCollection")
+        self.assertEqual(len(p), 2,
+                         "previous() collection has incorrect length")
+        self.assertIn("pagination", p.metadata)
+        self.assertIn("next", p.metadata["pagination"],
+                      "previous() collection doesn't have a next page")
+
+        with self.assertRaises(IndexError, msg="previous() did not raise with no previous page"):
+            p.previous()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -55,4 +55,5 @@ class TestCase(unittest.TestCase):
         code = kwargs.pop('code', 200)
 
         self.http.respond_to(
-          method, url, headers, body=body, code=code)
+            method, url, headers, body=body, code=code,
+            response_headers=kwargs.pop('response_headers', None))


### PR DESCRIPTION
fixes #337 

This PR implements cursor pagination which was introduced with the 2019-07 version of the Shopify API by implementing a new subclass of `pyactiveresource.Collection` which is able to handle the cursor pagination headers sent with the response. The returned object from `ShopifyResource.find()` has `next` and `previous` methods and by default caches pages. This PR also introduces a `PaginatedIterator` class which is used to iterate over a large number of pages in a memory-efficient manner as it only keeps the current page in memory.

Usage examples:
```python
# iterate over all products
import shopify
products = shopify.Product.find()
for item in products:
  # this will fetch next pages and iterate over them as necessary,
  # thereby iterating over every product
  do_something_with_product(item)

# get first 2 pages of products with custom arguments
page_one = shopify.Product.find(limit=100)
page_two = page_one.next(limit=25)

# iterate with PageIterator
for page in shopify.PageIterator(shopify.Product.find()):
  for item in page:
    do_something_with_product(item)
```

This PR depends on shopify/pyactiveresource#29 so I have currently set it as a draft PR. Once that is merged I will un-draft this one.