### PR TITLE
add version 2020-01 to known versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== Version 5.1.2
+* Add version 2020-01 to known ApiVersions. This version will not be usable until October 2019.
+
 == Version 5.1.1
 * Fix initializing API with basic auth URL.
 

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -28,6 +28,7 @@ class ApiVersion(object):
         cls.define_version(Release('2019-04'))
         cls.define_version(Release('2019-07'))
         cls.define_version(Release('2019-10'))
+        cls.define_version(Release('2020-01'))
 
     @classmethod
     def clear_defined_versions(cls):

--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = '5.1.1'
+VERSION = '5.1.2'


### PR DESCRIPTION
Just preemptively getting the 2020-01 release candidate version ready to go in case we don't get dynamic versions checked off prior to the October 1st.  Bumps the egg (wheel? lib?  🐍?) to version 5.1.2.

This version does not exist yet but it will become the release candidate come October. Attempting to use it before October 2019 will result in an unknown version error from the server.