### PR TITLE
enable shopify_api.py to load local modules

### DIFF
--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -13,6 +13,8 @@ import six
 from six.moves import input, map
 
 def start_interpreter(**variables):
+    # add the current working directory to the sys paths
+    sys.path.append(os.getcwd())
     console = type('shopify ' + shopify.version.VERSION, (code.InteractiveConsole, object), {})
     import readline
     console(variables).interact()


### PR DESCRIPTION
After activating the console via shopify_api.py i could not access local python modules.  I needed to add the current working directory to the sys paths before starting the console.