### PR TITLE
Cursor Pagination

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name=NAME,
       scripts=['scripts/shopify_api.py'],
       license='MIT License',
       install_requires=[
-          'pyactiveresource>=2.1.2',
+          'pyactiveresource>=2.2.0',
           'PyYAML',
           'six',
       ],

--- a/shipit.yml
+++ b/shipit.yml
@@ -2,4 +2,4 @@ deploy:
   override:
     - assert-egg-version-tag setup.py
     - python setup.py sdist
-    - twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+    - twine upload --repository-url https://upload.pypi.org/legacy/ -u shopify -p $PYPI_PASSWORD_SHOPIFY dist/*

--- a/shopify/__init__.py
+++ b/shopify/__init__.py
@@ -3,3 +3,4 @@ from shopify.session import Session, ValidationException
 from shopify.resources import *
 from shopify.limits import Limits
 from shopify.api_version import *
+from shopify.collection import PaginatedIterator

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -39,17 +39,17 @@ class PaginatedCollection(Collection):
         self._current_iter = None
         self._no_iter_next = kwargs.pop("no_iter_next", False)
 
-    def has_previous(self):
+    def has_previous_page(self):
         """Returns true if the current page has any previous pages before it.
         """
         return bool(self.previous_page_url)
 
-    def has_next(self):
+    def has_next_page(self):
         """Returns true if the current page has any pages beyond the current position.
         """
         return bool(self.next_page_url)
 
-    def previous(self, no_cache=False):
+    def previous_page(self, no_cache=False):
         """Returns the previous page of items.
 
         Args:
@@ -59,11 +59,11 @@ class PaginatedCollection(Collection):
         """
         if self._previous:
             return self._previous
-        elif not self.has_previous():
+        elif not self.has_previous_page():
             raise IndexError("No previous page")
         return self.__fetch_page(self.previous_page_url, no_cache)
 
-    def next(self, no_cache=False):
+    def next_page(self, no_cache=False):
         """Returns the next page of items.
 
         Args:
@@ -73,7 +73,7 @@ class PaginatedCollection(Collection):
         """
         if self._next:
             return self._next
-        elif not self.has_next():
+        elif not self.has_next_page():
             raise IndexError("No next page")
         return self.__fetch_page(self.next_page_url, no_cache)
 
@@ -96,7 +96,7 @@ class PaginatedCollection(Collection):
         try:
             if not self._current_iter:
                 self._current_iter = self
-            self._current_iter = self.next()
+            self._current_iter = self.next_page()
 
             for item in self._current_iter:
                 yield item
@@ -138,6 +138,6 @@ class PaginatedIterator(object):
         while True:
             yield current_page
             try:
-                current_page = current_page.next(no_cache=True)
+                current_page = current_page.next_page(no_cache=True)
             except IndexError:
                 return

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -1,0 +1,143 @@
+from pyactiveresource.collection import Collection
+from six.moves.urllib.parse import urlparse, parse_qs
+import cgi
+
+class PaginatedCollection(Collection):
+    """
+    A subclass of Collection which allows cycling through pages of
+    data through cursor-based pagination.
+
+    :next_page_url contains a url for fetching the next page
+    :previous_page_url contains a url for fetching the previous page
+
+    You can use next_page_url and previous_page_url to fetch the next page
+    of data by calling Resource.find(from_=page.next_page_url)
+    """
+
+    def __init__(self, *args, **kwargs):
+        """If given a Collection object as an argument, inherit its metadata."""
+
+        metadata = kwargs.pop("metadata", None)
+        obj = args[0]
+        if isinstance(obj, Collection):
+            if metadata:
+                metadata.update(obj.metadata)
+            else:
+                metadata = obj.metadata
+            super(PaginatedCollection, self).__init__(obj, metadata=metadata)
+        else:
+            super(PaginatedCollection, self).__init__(metadata=metadata or {},
+                                                      *args, **kwargs)
+        if not ("pagination" in self.metadata and "resource_class" in self.metadata):
+            raise AttributeError("Cursor-based pagination requires \"pagination\" and \"resource_class\" attributes in the metadata.")
+
+        self.next_page_url = self.metadata["pagination"].get('next', None)
+        self.previous_page_url = self.metadata["pagination"].get('previous', None)
+
+        self._next = None
+        self._previous = None
+        self._current_iter = None
+        self._no_iter_next = kwargs.pop("no_iter_next", False)
+
+    def has_previous(self):
+        """Returns true if the current page has any previous pages before it.
+        """
+        return bool(self.previous_page_url)
+
+    def has_next(self):
+        """Returns true if the current page has any pages beyond the current position.
+        """
+        return bool(self.next_page_url)
+
+    def previous(self, no_cache=False):
+        """Returns the previous page of items.
+
+        Args:
+            no_cache: If true the page will not be cached.
+        Returns:
+            A PaginatedCollection object with the new data set.
+        """
+        if self._previous:
+            return self._previous
+        elif not self.has_previous():
+            raise IndexError("No previous page")
+        return self.__fetch_page(self.previous_page_url, no_cache)
+
+    def next(self, no_cache=False):
+        """Returns the next page of items.
+
+        Args:
+            no_cache: If true the page will not be cached.
+        Returns:
+            A PaginatedCollection object with the new data set.
+        """
+        if self._next:
+            return self._next
+        elif not self.has_next():
+            raise IndexError("No next page")
+        return self.__fetch_page(self.next_page_url, no_cache)
+
+    def __fetch_page(self, url, no_cache=False):
+        next = self.metadata["resource_class"].find(from_=url)
+        if not no_cache:
+            self._next = next
+            self._next._previous = self
+        next._no_iter_next = self._no_iter_next
+        return next
+
+    def __iter__(self):
+        """Iterates through all items, also fetching other pages."""
+        for item in super(PaginatedCollection, self).__iter__():
+            yield item
+
+        if self._no_iter_next:
+            return
+
+        try:
+            if not self._current_iter:
+                self._current_iter = self
+            self._current_iter = self.next()
+
+            for item in self._current_iter:
+                yield item
+        except IndexError:
+            return
+
+    def __len__(self):
+        """If fetched count all the pages."""
+
+        if self._next:
+            count = len(self._next)
+        else:
+            count = 0
+        return count + super(PaginatedCollection, self).__len__()
+
+
+class PaginatedIterator(object):
+    """
+    This class implements an iterator over paginated collections which aims to
+    be more memory-efficient by not keeping more than one page in memory at a
+    time.
+
+    >>> from shopify import Product, PaginatedIterator
+    >>> for page in PaginatedIterator(Product.find()):
+    ...     for item in page:
+    ...         do_something(item)
+    ...
+    # every page and the page items are iterated
+    """
+    def __init__(self, collection):
+        if not isinstance(collection, PaginatedCollection):
+            raise TypeError("PaginatedIterator expects a PaginatedCollection instance")
+        self.collection = collection
+        self.collection._no_iter_next = True
+
+    def __iter__(self):
+        """Iterate over pages, returning one page at a time."""
+        current_page = self.collection
+        while True:
+            yield current_page
+            try:
+                current_page = current_page.next(no_cache=True)
+            except IndexError:
+                return

--- a/shopify/resources/customer.py
+++ b/shopify/resources/customer.py
@@ -17,9 +17,9 @@ class Customer(ShopifyResource, mixins.Metafields):
            limit: Amount of results (default: 50) (maximum: 250)
            fields: comma-seperated list of fields to include in the response
         Returns:
-           An array of customers.
+           A Collection of customers.
         """
-        return cls._build_list(cls.get("search", **kwargs))
+        return cls._build_collection(cls.get("search", **kwargs))
 
     def send_invite(self, customer_invite = CustomerInvite()):
         resource = self.post("send_invite", customer_invite.encode())

--- a/shopify/resources/customer_saved_search.py
+++ b/shopify/resources/customer_saved_search.py
@@ -5,4 +5,4 @@ from .customer import Customer
 class CustomerSavedSearch(ShopifyResource):
 
     def customers(cls, **kwargs):
-        return Customer._build_list(cls.get("customers", **kwargs))
+        return Customer._build_collection(cls.get("customers", **kwargs))

--- a/test/fixtures/products.json
+++ b/test/fixtures/products.json
@@ -1,0 +1,206 @@
+[
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 1,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 1,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  },
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 2,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 2,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 2,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  },
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 3,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 2,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 2,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  },
+  {
+    "product_type": "Cult Products",
+    "handle": "ipod-nano",
+    "created_at": "2011-10-20T14:05:13-04:00",
+    "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+    "title": "IPod Nano - 8GB",
+    "template_suffix": null,
+    "updated_at": "2011-10-20T14:05:13-04:00",
+    "id": 4,
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "images": [
+      {
+        "position": 1,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "product_id": 4,
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+        "id": 850703190
+      }
+    ],
+    "variants": [
+      {
+        "position": 1,
+        "price": "199.00",
+        "product_id": 4,
+        "created_at": "2011-10-20T14:05:13-04:00",
+        "requires_shipping": true,
+        "title": "Pink",
+        "inventory_quantity": 10,
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "updated_at": "2011-10-20T14:05:13-04:00",
+        "inventory_management": "shopify",
+        "id": 808950810,
+        "taxable": true,
+        "grams": 200,
+        "sku": "IPOD2008PINK",
+        "option1": "Pink",
+        "fulfillment_service": "manual",
+        "option2": null,
+        "option3": null
+      }
+    ],
+    "vendor": "Apple",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "options": [
+      {
+        "name": "Title"
+      }
+    ]
+  }
+]

--- a/test/fixtures/transactions.json
+++ b/test/fixtures/transactions.json
@@ -1,0 +1,29 @@
+[
+  {
+    "amount": "409.94",
+    "authorization": "authorization-key",
+    "created_at": "2005-08-01T11:57:11-04:00",
+    "gateway": "bogus",
+    "id": 389404469,
+    "kind": "authorization",
+    "location_id": null,
+    "message": null,
+    "order_id": 450789469,
+    "parent_id": null,
+    "status": "success",
+    "test": false,
+    "user_id": null,
+    "device_id": null,
+    "receipt": {
+      "testcase": true,
+      "authorization": "123456"
+    },
+    "payment_details": {
+      "avs_result_code": null,
+      "credit_card_bin": null,
+      "cvv_result_code": null,
+      "credit_card_number": "XXXX-XXXX-XXXX-4242",
+      "credit_card_company": "Visa"
+    }
+  }
+]

--- a/test/order_test.py
+++ b/test/order_test.py
@@ -44,6 +44,6 @@ class OrderTest(TestCase):
     def test_get_order_transaction(self):
         self.fake('orders/450789469', method='GET', body=self.load_fixture('order'))
         order = shopify.Order.find(450789469)
-        self.fake('orders/450789469/transactions', method='GET', body=self.load_fixture('transaction'))
+        self.fake('orders/450789469/transactions', method='GET', body=self.load_fixture('transactions'))
         transactions = order.transactions()
         self.assertEqual("409.94", transactions[0].amount)

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -33,40 +33,41 @@ class PaginationTest(TestCase):
         self.assertIsInstance(items, shopify.collection.PaginatedCollection, "find() result is not PaginatedCollection")
         self.assertEqual(len(items), 2, "find() result has incorrect length")
 
-    def test_pagination_next(self):
+    def test_pagination_next_page(self):
         c = shopify.Product.find(limit=2)
         self.assertEqual(c.next_page_url, self.next_page_url, "next url is incorrect")
-        n = c.next()
+        n = c.next_page()
         self.assertEqual(n.previous_page_url, self.prev_page_url, "prev url is incorrect")
         self.assertIsInstance(n, shopify.collection.PaginatedCollection,
-                              "next() result is not PaginatedCollection")
-        self.assertEqual(len(n), 2, "next() collection has incorrect length")
+                              "next_page() result is not PaginatedCollection")
+        self.assertEqual(len(n), 2, "next_page() collection has incorrect length")
         self.assertIn("pagination", n.metadata)
         self.assertIn("previous", n.metadata["pagination"],
-                      "next() collection doesn't have a previous page")
+                      "next_page() collection doesn't have a previous page")
 
-        with self.assertRaises(IndexError, msg="next() did not raise with no next page"):
-            n.next()
+        with self.assertRaises(IndexError, msg="next_page() did not raise with no next page"):
+            n.next_page()
 
     def test_pagination_previous(self):
         c = shopify.Product.find(limit=2)
         self.assertEqual(c.next_page_url, self.next_page_url, "next url is incorrect")
-        self.assertTrue(c.has_next())
-        n = c.next()
+        self.assertTrue(c.has_next_page())
+        n = c.next_page()
         self.assertEqual(n.previous_page_url, self.prev_page_url, "prev url is incorrect")
+        self.assertTrue(n.has_previous_page())
 
-        p = n.previous()
+        p = n.previous_page()
 
         self.assertIsInstance(p, shopify.collection.PaginatedCollection,
-                              "previous() result is not PaginatedCollection")
+                              "previous_page() result is not PaginatedCollection")
         self.assertEqual(len(p), 4, # cached
-                         "previous() collection has incorrect length")
+                         "previous_page() collection has incorrect length")
         self.assertIn("pagination", p.metadata)
         self.assertIn("next", p.metadata["pagination"],
-                      "previous() collection doesn't have a next page")
+                      "previous_page() collection doesn't have a next page")
 
-        with self.assertRaises(IndexError, msg="previous() did not raise with no previous page"):
-            p.previous()
+        with self.assertRaises(IndexError, msg="previous_page() did not raise with no previous page"):
+            p.previous_page()
 
     def test_paginated_collection_iterator(self):
         c = shopify.Product.find(limit=2)
@@ -82,11 +83,11 @@ class PaginationTest(TestCase):
     def test_paginated_collection_no_cache(self):
         c = shopify.Product.find(limit=2)
 
-        n = c.next(no_cache=True)
+        n = c.next_page(no_cache=True)
         self.assertIsNone(c._next, "no_cache=True still caches")
         self.assertIsNone(n._previous, "no_cache=True still caches")
 
-        p = n.previous(no_cache=True)
+        p = n.previous_page(no_cache=True)
         self.assertIsNone(p._next, "no_cache=True still caches")
         self.assertIsNone(n._previous, "no_cache=True still caches")
 

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -1,0 +1,111 @@
+import shopify
+import json
+from test.test_helper import TestCase
+
+class PaginationTest(TestCase):
+
+    def setUp(self):
+        super(PaginationTest, self).setUp()
+        prefix = self.http.site + "/admin/api/unstable"
+
+        self.fixture = json.loads(self.load_fixture('products'))
+        self.next_page_url = prefix + "/products.json?limit=2&page_info=FOOBAR"
+        self.prev_page_url = prefix + "/products.json?limit=2&page_info=BAZQUUX"
+
+        next_headers = {"Link": "<" + self.next_page_url + ">; rel=\"next\""}
+        prev_headers = {"Link": "<" + self.prev_page_url + ">; rel=\"previous\""}
+
+        self.fake("products",
+                  url=prefix + "/products.json?limit=2",
+                  body=json.dumps({ "products": self.fixture[:2] }),
+                  response_headers=next_headers)
+        self.fake("products",
+                  url=prefix + "/products.json?limit=2&page_info=FOOBAR",
+                  body=json.dumps({ "products": self.fixture[2:4] }),
+                  response_headers=prev_headers)
+        self.fake("products",
+                  url=prefix + "/products.json?limit=2&page_info=BAZQUUX",
+                  body=json.dumps({ "products": self.fixture[:2] }),
+                  response_headers=next_headers)
+
+    def test_paginated_collection(self):
+        items = shopify.Product.find(limit=2)
+        self.assertIsInstance(items, shopify.collection.PaginatedCollection, "find() result is not PaginatedCollection")
+        self.assertEqual(len(items), 2, "find() result has incorrect length")
+
+    def test_pagination_next(self):
+        c = shopify.Product.find(limit=2)
+        self.assertEqual(c.next_page_url, self.next_page_url, "next url is incorrect")
+        n = c.next()
+        self.assertEqual(n.previous_page_url, self.prev_page_url, "prev url is incorrect")
+        self.assertIsInstance(n, shopify.collection.PaginatedCollection,
+                              "next() result is not PaginatedCollection")
+        self.assertEqual(len(n), 2, "next() collection has incorrect length")
+        self.assertIn("pagination", n.metadata)
+        self.assertIn("previous", n.metadata["pagination"],
+                      "next() collection doesn't have a previous page")
+
+        with self.assertRaises(IndexError, msg="next() did not raise with no next page"):
+            n.next()
+
+    def test_pagination_previous(self):
+        c = shopify.Product.find(limit=2)
+        self.assertEqual(c.next_page_url, self.next_page_url, "next url is incorrect")
+        self.assertTrue(c.has_next())
+        n = c.next()
+        self.assertEqual(n.previous_page_url, self.prev_page_url, "prev url is incorrect")
+
+        p = n.previous()
+
+        self.assertIsInstance(p, shopify.collection.PaginatedCollection,
+                              "previous() result is not PaginatedCollection")
+        self.assertEqual(len(p), 4, # cached
+                         "previous() collection has incorrect length")
+        self.assertIn("pagination", p.metadata)
+        self.assertIn("next", p.metadata["pagination"],
+                      "previous() collection doesn't have a next page")
+
+        with self.assertRaises(IndexError, msg="previous() did not raise with no previous page"):
+            p.previous()
+
+    def test_paginated_collection_iterator(self):
+        c = shopify.Product.find(limit=2)
+
+        i = iter(c)
+        self.assertEqual(next(i).id, 1)
+        self.assertEqual(next(i).id, 2)
+        self.assertEqual(next(i).id, 3)
+        self.assertEqual(next(i).id, 4)
+        with self.assertRaises(StopIteration):
+            next(i)
+
+    def test_paginated_collection_no_cache(self):
+        c = shopify.Product.find(limit=2)
+
+        n = c.next(no_cache=True)
+        self.assertIsNone(c._next, "no_cache=True still caches")
+        self.assertIsNone(n._previous, "no_cache=True still caches")
+
+        p = n.previous(no_cache=True)
+        self.assertIsNone(p._next, "no_cache=True still caches")
+        self.assertIsNone(n._previous, "no_cache=True still caches")
+
+    def test_paginated_iterator(self):
+        c = shopify.Product.find(limit=2)
+
+        i = iter(shopify.PaginatedIterator(c))
+
+        first_page = iter(next(i))
+        self.assertEqual(next(first_page).id, 1)
+        self.assertEqual(next(first_page).id, 2)
+        with self.assertRaises(StopIteration):
+            next(first_page)
+
+        second_page = iter(next(i))
+        self.assertEqual(next(second_page).id, 3)
+        self.assertEqual(next(second_page).id, 4)
+        with self.assertRaises(StopIteration):
+            next(second_page)
+
+        with self.assertRaises(StopIteration):
+            next(i)

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -7,8 +7,8 @@ class PaginationTest(TestCase):
     def setUp(self):
         super(PaginationTest, self).setUp()
         prefix = self.http.site + "/admin/api/unstable"
+        fixture = json.loads(self.load_fixture('products').decode())
 
-        self.fixture = json.loads(self.load_fixture('products'))
         self.next_page_url = prefix + "/products.json?limit=2&page_info=FOOBAR"
         self.prev_page_url = prefix + "/products.json?limit=2&page_info=BAZQUUX"
 
@@ -17,15 +17,15 @@ class PaginationTest(TestCase):
 
         self.fake("products",
                   url=prefix + "/products.json?limit=2",
-                  body=json.dumps({ "products": self.fixture[:2] }),
+                  body=json.dumps({ "products": fixture[:2] }),
                   response_headers=next_headers)
         self.fake("products",
                   url=prefix + "/products.json?limit=2&page_info=FOOBAR",
-                  body=json.dumps({ "products": self.fixture[2:4] }),
+                  body=json.dumps({ "products": fixture[2:4] }),
                   response_headers=prev_headers)
         self.fake("products",
                   url=prefix + "/products.json?limit=2&page_info=BAZQUUX",
-                  body=json.dumps({ "products": self.fixture[:2] }),
+                  body=json.dumps({ "products": fixture[:2] }),
                   response_headers=next_headers)
 
     def test_paginated_collection(self):

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -55,4 +55,5 @@ class TestCase(unittest.TestCase):
         code = kwargs.pop('code', 200)
 
         self.http.respond_to(
-          method, url, headers, body=body, code=code)
+            method, url, headers, body=body, code=code,
+            response_headers=kwargs.pop('response_headers', None))


### PR DESCRIPTION
### Problem
This library still doesnt support cursor based pagination. This will add in that functionality.

### Solution
This is based largely off of @emdemir work however I have made some critical changes that we have needed when doing this work in other repos

- Using the links directly to fetch the next page. This makes it a lot easier to manage 
- Exposing next and previous links so that they can be fetched across requests, if they are stored in a session.
- has_next and has_previous methods for introspecting if the data is available.
 
#### misc changes
- deployment fixed
- update pyactiveresource
- fixed an order test which was broken for some reason