### PR TITLE
Cast all collections to PaginatedCollection

### DIFF
--- a/shopify/base.py
+++ b/shopify/base.py
@@ -208,43 +208,7 @@ class ShopifyResource(ActiveResource, mixins.Countable):
     @classmethod
     def find(cls, id_=None, from_=None, **kwargs):
         """Checks the resulting collection for pagination metadata."""
-
-        collection = super(ShopifyResource, cls).find(id_=id_, from_=from_,
-                                                      **kwargs)
-
-        # pyactiveresource currently sends all headers from the response with
-        # the collection.
-        if isinstance(collection, Collection) and \
-           "headers" in collection.metadata:
-            headers = collection.metadata["headers"]
-            if "Link" in headers:
-                pagination = cls._parse_pagination(headers["Link"])
-                return PaginatedCollection(collection, metadata={
-                    "pagination": pagination,
-                    "resource_class": cls
-                })
-
+        collection = super(ShopifyResource, cls).find(id_=id_, from_=from_, **kwargs)
+        if isinstance(collection, Collection) and "headers" in collection.metadata:
+            return PaginatedCollection(collection, metadata={"resource_class": cls})
         return collection
-
-    @classmethod
-    def _parse_pagination(cls, data):
-        """Parses a Link header into a dict for cursor-based pagination.
-
-        Args:
-            data: The Link header value as a string.
-        Returns:
-            A dict with rel names as keys and URLs as values.
-        """
-
-        # Example Link header:
-        # <https://xxx.shopify.com/admin/...>; rel="previous",
-        # <https://xxx.shopify.com/admin/...>; rel="next"
-
-        values = data.split(", ")
-
-        result = {}
-        for value in values:
-            link, rel = value.split("; ")
-            result[rel.split('"')[1]] = link[1:-1]
-
-        return result

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -29,7 +29,7 @@ class PaginatedCollection(Collection):
             super(PaginatedCollection, self).__init__(metadata=metadata or {}, *args, **kwargs)
 
         if not ("resource_class" in self.metadata):
-            raise AttributeError("Cursor-based pagination requires \"pagination\" and \"resource_class\" attributes in the metadata.")
+            raise AttributeError("Cursor-based pagination requires a \"resource_class\" attribute in the metadata.")
 
         self.metadata["pagination"] = self.__parse_pagination()
         self.next_page_url = self.metadata["pagination"].get('next', None)

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -41,11 +41,9 @@ class PaginatedCollection(Collection):
         self._no_iter_next = kwargs.pop("no_iter_next", False)
 
     def __parse_pagination(self):
-        headers = self.metadata["headers"]
-        if "Link" not in headers:
+        if "headers" not in self.metadata or "Link" not in self.metadata["headers"]:
             return {}
-        data = headers["Link"]
-        values = data.split(", ")
+        values = self.metadata["headers"]["Link"].split(", ")
         result = {}
         for value in values:
             link, rel = value.split("; ")

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -26,11 +26,12 @@ class PaginatedCollection(Collection):
                 metadata = obj.metadata
             super(PaginatedCollection, self).__init__(obj, metadata=metadata)
         else:
-            super(PaginatedCollection, self).__init__(metadata=metadata or {},
-                                                      *args, **kwargs)
-        if not ("pagination" in self.metadata and "resource_class" in self.metadata):
+            super(PaginatedCollection, self).__init__(metadata=metadata or {}, *args, **kwargs)
+
+        if not ("resource_class" in self.metadata):
             raise AttributeError("Cursor-based pagination requires \"pagination\" and \"resource_class\" attributes in the metadata.")
 
+        self.metadata["pagination"] = self.__parse_pagination()
         self.next_page_url = self.metadata["pagination"].get('next', None)
         self.previous_page_url = self.metadata["pagination"].get('previous', None)
 
@@ -38,6 +39,18 @@ class PaginatedCollection(Collection):
         self._previous = None
         self._current_iter = None
         self._no_iter_next = kwargs.pop("no_iter_next", False)
+
+    def __parse_pagination(self):
+        headers = self.metadata["headers"]
+        if "Link" not in headers:
+            return {}
+        data = headers["Link"]
+        values = data.split(", ")
+        result = {}
+        for value in values:
+            link, rel = value.split("; ")
+            result[rel.split('"')[1]] = link[1:-1]
+        return result
 
     def has_previous_page(self):
         """Returns true if the current page has any previous pages before it.

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -28,6 +28,13 @@ class PaginationTest(TestCase):
                   body=json.dumps({ "products": fixture[:2] }),
                   response_headers=next_headers)
 
+    def test_nonpaginates_collection(self):
+        self.fake('draft_orders', method='GET', code=200, body=self.load_fixture('draft_orders'))
+        draft_orders = shopify.DraftOrder.find()
+        self.assertEqual(1, len(draft_orders))
+        self.assertEqual(517119332, draft_orders[0].id)
+        self.assertIsInstance(draft_orders, shopify.collection.PaginatedCollection, "find() result is not PaginatedCollection")
+
     def test_paginated_collection(self):
         items = shopify.Product.find(limit=2)
         self.assertIsInstance(items, shopify.collection.PaginatedCollection, "find() result is not PaginatedCollection")


### PR DESCRIPTION
fixes #353 

This allows PaginatedCollection to handle all collections if they have pages or not. This way the interface is more consistent and you have to do fewer checks for types.

@Philpax I believe you asked for this in the original PR as well. 