### PR TITLE
Adding some flexibility into the pagination

### DIFF
--- a/shopify/base.py
+++ b/shopify/base.py
@@ -210,5 +210,5 @@ class ShopifyResource(ActiveResource, mixins.Countable):
         """Checks the resulting collection for pagination metadata."""
         collection = super(ShopifyResource, cls).find(id_=id_, from_=from_, **kwargs)
         if isinstance(collection, Collection) and "headers" in collection.metadata:
-            return PaginatedCollection(collection, metadata={"resource_class": cls})
+            return PaginatedCollection(collection, metadata={"resource_class": cls}, **kwargs)
         return collection

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -38,7 +38,7 @@ class PaginatedCollection(Collection):
         self._next = None
         self._previous = None
         self._current_iter = None
-        self._no_iter_next = kwargs.pop("no_iter_next", False)
+        self._no_iter_next = kwargs.pop("no_iter_next", True)
 
     def __parse_pagination(self):
         if "headers" not in self.metadata:

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -41,11 +41,15 @@ class PaginatedCollection(Collection):
         self._no_iter_next = kwargs.pop("no_iter_next", False)
 
     def __parse_pagination(self):
-        if "headers" not in self.metadata or "Link" not in self.metadata["headers"]:
+        if "headers" not in self.metadata:
             return {}
-        values = self.metadata["headers"]["Link"].split(", ")
+
+        values = self.metadata["headers"].get("Link", self.metadata["headers"].get("link", None))
+        if values is None:
+            return {}
+
         result = {}
-        for value in values:
+        for value in values.split(", "):
             link, rel = value.split("; ")
             result[rel.split('"')[1]] = link[1:-1]
         return result

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -82,8 +82,6 @@ class PaginationTest(TestCase):
         i = iter(c)
         self.assertEqual(next(i).id, 1)
         self.assertEqual(next(i).id, 2)
-        self.assertEqual(next(i).id, 3)
-        self.assertEqual(next(i).id, 4)
         with self.assertRaises(StopIteration):
             next(i)
 


### PR DESCRIPTION
fixes #357 
fixes #356 

This adds 2 things.

### Link Header
It seems like some versions of urlib mess with the case of header names. I have added in flexibility to this to check for Link and link so that it will work in any case

### no_iter_next
kwargs were not passed to the Paginated collection so there was no way for a user to specify the attribute no_iter_next in the initialization. I have passed along the kwargs now and it can not be specified

@GhostApps @Philpax @dasony for review of changes