### PR TITLE
Solves API version +2019-10 fails with variant updates

### DIFF
--- a/shopify/base.py
+++ b/shopify/base.py
@@ -12,6 +12,8 @@ from shopify.collection import PaginatedCollection
 from pyactiveresource.collection import Collection
 
 # Store the response from the last request in the connection object
+
+
 class ShopifyConnection(pyactiveresource.connection.Connection):
     response = None
 
@@ -29,6 +31,8 @@ class ShopifyConnection(pyactiveresource.connection.Connection):
         return self.response
 
 # Inherit from pyactiveresource's metaclass in order to use ShopifyConnection
+
+
 class ShopifyResourceMeta(ResourceMeta):
 
     @property
@@ -139,17 +143,12 @@ class ShopifyResourceMeta(ResourceMeta):
 
     prefix_source = property(get_prefix_source, set_prefix_source, None,
                              'prefix for lookups for this type of object.')
-    def get_version(cls):
-        return getattr(cls._threadlocal, 'version', ShopifyResource._version)
-
-    def set_version(cls, value):
-        ShopifyResource._version = cls._threadlocal.version = value
-
-    version = property(get_version, set_version, None,
-                      'Shopify Api Version')
 
     def get_version(cls):
-        return getattr(cls._threadlocal, 'version', ShopifyResource._version)
+        if hasattr(cls._threadlocal, 'version') or ShopifyResource._version:
+            return getattr(cls._threadlocal, 'version', ShopifyResource._version)
+        else:
+            return ShopifyResource._site.split('/')[-1]
 
     def set_version(cls, value):
         ShopifyResource._version = cls._threadlocal.version = value
@@ -164,14 +163,15 @@ class ShopifyResourceMeta(ResourceMeta):
         ShopifyResource._url = cls._threadlocal.url = value
 
     url = property(get_url, set_url, None,
-                      'Base URL including protocol and shopify domain')
+                   'Base URL including protocol and shopify domain')
 
 
 @six.add_metaclass(ShopifyResourceMeta)
 class ShopifyResource(ActiveResource, mixins.Countable):
     _format = formats.JSONFormat
     _threadlocal = threading.local()
-    _headers = {'User-Agent': 'ShopifyPythonAPI/%s Python/%s' % (shopify.VERSION, sys.version.split(' ', 1)[0])}
+    _headers = {
+        'User-Agent': 'ShopifyPythonAPI/%s Python/%s' % (shopify.VERSION, sys.version.split(' ', 1)[0])}
     _version = None
     _url = None
 

--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -38,7 +38,9 @@ class Product(ShopifyResource, mixins.Metafields, mixins.Events):
         start_api_version = '201910'
         if api_version >= start_api_version:
             for variant in self.variants:
-                del variant.attributes['inventory_quantity']
-                del variant.attributes['old_inventory_quantity']
+                if variant.attributes.get('inventory_quantity'):
+                    del variant.attributes['inventory_quantity']
+                if variant.attributes.get('old_inventory_quantity'):
+                    del variant.attributes['old_inventory_quantity']
 
         return super(ShopifyResource, self).save()

--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -38,9 +38,8 @@ class Product(ShopifyResource, mixins.Metafields, mixins.Events):
         start_api_version = '201910'
         if api_version >= start_api_version:
             for variant in self.variants:
-                if variant.attributes.get('inventory_quantity'):
+                if 'inventory_quantity' in variant.attributes:
                     del variant.attributes['inventory_quantity']
-                if variant.attributes.get('old_inventory_quantity'):
+                if 'old_inventory_quantity' in variant.attributes:
                     del variant.attributes['old_inventory_quantity']
-
         return super(ShopifyResource, self).save()

--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -30,3 +30,15 @@ class Product(ShopifyResource, mixins.Metafields, mixins.Events):
     def add_variant(self, variant):
         variant.attributes['product_id'] = self.id
         return variant.save()
+
+    def save(self):
+        # github issue 347
+        # todo: how to get the api version without split & strip
+        api_version = ShopifyResource._site.split('/')[-1].strip('-')
+        start_api_version = '201910'
+        if api_version >= start_api_version:
+            for variant in self.variants:
+                del variant.attributes['inventory_quantity']
+                del variant.attributes['old_inventory_quantity']
+
+        return super(ShopifyResource, self).save()

--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -32,11 +32,10 @@ class Product(ShopifyResource, mixins.Metafields, mixins.Events):
         return variant.save()
 
     def save(self):
-        # github issue 347
-        # todo: how to get the api version without split & strip
-        api_version = ShopifyResource._site.split('/')[-1].strip('-')
         start_api_version = '201910'
-        if api_version >= start_api_version:
+        api_version = ShopifyResource.version
+        if api_version and (
+                api_version.strip('-') >= start_api_version) and api_version != 'unstable':
             for variant in self.variants:
                 if 'inventory_quantity' in variant.attributes:
                     del variant.attributes['inventory_quantity']

--- a/shopify/resources/variant.py
+++ b/shopify/resources/variant.py
@@ -22,9 +22,9 @@ class Variant(ShopifyResource, mixins.Metafields):
         api_version = ShopifyResource._site.split('/')[-1].strip('-')
         start_api_version = '201910'
         if api_version >= start_api_version:
-            if self.attributes.get('inventory_quantity'):
+            if 'inventory_quantity' in self.attributes:
                 del self.attributes['inventory_quantity']
-            if self.attributes.get('old_inventory_quantity'):
+            if 'old_inventory_quantity' in self.attributes:
                 del self.attributes['old_inventory_quantity']
 
         return super(ShopifyResource, self).save()

--- a/shopify/resources/variant.py
+++ b/shopify/resources/variant.py
@@ -22,7 +22,9 @@ class Variant(ShopifyResource, mixins.Metafields):
         api_version = ShopifyResource._site.split('/')[-1].strip('-')
         start_api_version = '201910'
         if api_version >= start_api_version:
-            del self.attributes['inventory_quantity']
-            del self.attributes['old_inventory_quantity']
+            if self.attributes.get('inventory_quantity'):
+                del self.attributes['inventory_quantity']
+            if self.attributes.get('old_inventory_quantity'):
+                del self.attributes['old_inventory_quantity']
 
         return super(ShopifyResource, self).save()

--- a/shopify/resources/variant.py
+++ b/shopify/resources/variant.py
@@ -16,4 +16,13 @@ class Variant(ShopifyResource, mixins.Metafields):
     def save(self):
         if 'product_id' not in self._prefix_options:
             self._prefix_options['product_id'] = self.product_id
+
+        # github issue 347
+        # todo: how to get the api version without split & strip
+        api_version = ShopifyResource._site.split('/')[-1].strip('-')
+        start_api_version = '201910'
+        if api_version >= start_api_version:
+            del self.attributes['inventory_quantity']
+            del self.attributes['old_inventory_quantity']
+
         return super(ShopifyResource, self).save()

--- a/shopify/resources/variant.py
+++ b/shopify/resources/variant.py
@@ -17,11 +17,10 @@ class Variant(ShopifyResource, mixins.Metafields):
         if 'product_id' not in self._prefix_options:
             self._prefix_options['product_id'] = self.product_id
 
-        # github issue 347
-        # todo: how to get the api version without split & strip
-        api_version = ShopifyResource._site.split('/')[-1].strip('-')
         start_api_version = '201910'
-        if api_version >= start_api_version:
+        api_version = ShopifyResource.version
+        if api_version and (
+                api_version.strip('-') >= start_api_version) and api_version != 'unstable':
             if 'inventory_quantity' in self.attributes:
                 del self.attributes['inventory_quantity']
             if 'old_inventory_quantity' in self.attributes:


### PR DESCRIPTION
fixes #347


Hi, I think that PR can solve the problem about updating variants from api versions +2019-10, and the error 400.
