### PR TITLE
Handle saving of product with no variants specified

### DIFF
--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -36,9 +36,10 @@ class Product(ShopifyResource, mixins.Metafields, mixins.Events):
         api_version = ShopifyResource.version
         if api_version and (
                 api_version.strip('-') >= start_api_version) and api_version != 'unstable':
-            for variant in self.variants:
-                if 'inventory_quantity' in variant.attributes:
-                    del variant.attributes['inventory_quantity']
-                if 'old_inventory_quantity' in variant.attributes:
-                    del variant.attributes['old_inventory_quantity']
+            if 'variants' in self.product.attributes:
+                for variant in self.variants:
+                    if 'inventory_quantity' in variant.attributes:
+                        del variant.attributes['inventory_quantity']
+                    if 'old_inventory_quantity' in variant.attributes:
+                        del variant.attributes['old_inventory_quantity']
         return super(ShopifyResource, self).save()


### PR DESCRIPTION
Shopify API allows not setting all the attributes when changing a resource. It can be used as optimization to speed up things if some parts of a resource doesn't change.

Common scenario is to prevent variants update when saving product as there can be up to 100 variants per product and saving all takes a long time.

Recent update to delete `inventory_quantity` and `old_inventory_quantity` of variants when saving product broke the ability to delete variants to prevent them from saving. It was working fine in version 7.0.0.

This PR adds a check if the `variants` are defined on a product before attempt to delete `inventory_quantity` and `old_inventory_quantity` when saving.