### PR TITLE
Add optional customer_id support for Order.find()

### DIFF
--- a/shopify/resources/order.py
+++ b/shopify/resources/order.py
@@ -5,6 +5,16 @@ from .transaction import Transaction
 
 class Order(ShopifyResource, mixins.Metafields, mixins.Events):
 
+    _prefix_source = "/customers/$customer_id/"
+
+    @classmethod
+    def _prefix(cls, options={}):
+        customer_id = options.get("customer_id")
+        if customer_id:
+            return "%s/customers/%s" % (cls.site, customer_id)
+        else:
+            return cls.site
+
     def close(self):
         self._load_attributes_from_response(self.post("close"))
 


### PR DESCRIPTION
This PR adds allows users to retrieve orders for a specific customer by specifying a customer_id in the find() call.

The implementation is identical to that of Article