### PR TITLE
Add support for upcoming 2020-10 release, drop 2019-10

### DIFF
--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -25,10 +25,10 @@ class ApiVersion(object):
     @classmethod
     def define_known_versions(cls):
         cls.define_version(Unstable())
-        cls.define_version(Release('2019-10'))
         cls.define_version(Release('2020-01'))
         cls.define_version(Release('2020-04'))
         cls.define_version(Release('2020-07'))
+        cls.define_version(Release('2020-10'))
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION
This shouldn't be released before Oct 1.