### PR TITLE
Melaniew/add fulfillment orders coverage

### DIFF
--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -15,4 +15,12 @@ class Fulfillment(ShopifyResource):
 
 
 class FulfillmentOrders(ShopifyResource):
-    _prefix_source = "/orders/$order_id/"
+    @classmethod
+    def find(cls, id_=None, from_=None, **kwargs):
+        if id_:
+            cls._prefix_source = ''
+            resource = cls._find_single(id_, **kwargs)
+        else:
+            cls._prefix_source = "/orders/$order_id/"
+            resource = cls._find_every(**kwargs)
+        return resource

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -19,8 +19,7 @@ class FulfillmentOrders(ShopifyResource):
     def find(cls, id_=None, from_=None, **kwargs):
         if id_:
             cls._prefix_source = ''
-            resource = cls._find_single(id_, **kwargs)
         else:
             cls._prefix_source = "/orders/$order_id/"
-            resource = cls._find_every(**kwargs)
+        resource = super(FulfillmentOrders, cls).find(id_=id_, from_=from_, **kwargs)
         return resource

--- a/test/fixtures/fulfillment_orders.json
+++ b/test/fixtures/fulfillment_orders.json
@@ -1,0 +1,41 @@
+{
+    "fulfillment_order": {
+        "id": 2558888935587,
+        "shop_id": 49144037539,
+        "order_id": 2772506476707,
+        "assigned_location_id": 55896015011,
+        "fulfillment_service_handle": "manual",
+        "request_status": "unsubmitted",
+        "status": "open",
+        "supported_actions": [
+            "create_fulfillment"
+        ],
+        "destination": {
+            "address1": "Chestnut Street 92",
+            "address2": "",
+            "city": "Louisville",
+            "company": null,
+            "country": "United States",
+            "email": "",
+            "first_name": null,
+            "id": 207119551,
+            "last_name": null,
+            "phone": "555-625-1199",
+            "province": "Kentucky",
+            "zip": "40202"
+        },
+        "line_items": [
+            {
+                "id": 7118028439715,
+                "shop_id": 49144037539,
+                "fulfillment_order_id": 2558888935587,
+                "quantity": 1,
+                "line_item_id": 6037638185123,
+                "inventory_item_id": 38440146567331,
+                "fulfillable_quantity": 1,
+                "variant_id": 36317227843747
+            }
+        ],
+        "merchant_requests": []
+    }
+}

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -40,3 +40,17 @@ class FulFillmentTest(TestCase):
         self.assertEqual('pending', fulfillment.status)
         fulfillment.cancel()
         self.assertEqual('cancelled', fulfillment.status)
+
+class FulfillmentOrdersTest(TestCase):
+    def setUp(self):
+        super(FulfillmentOrdersTest, self).setUp()
+        self.fake("fulfillment_orders/2558888935587", method='GET', body=self.load_fixture('fulfillment_orders'))
+        self.fake("orders/2772506476707/fulfillment_orders", method='GET', body=self.load_fixture('fulfillment_orders'))
+
+    def test_get_fulfillment_orders(self):
+        fulfillment_orders = shopify.FulfillmentOrders.find(2558888935587)
+        self.assertEqual(2558888935587, fulfillment_orders.id)
+
+    def test_get_order_fulfillment_orders(self):
+        fulfillment_orders = shopify.FulfillmentOrders.find(order_id=2772506476707)
+        self.assertEqual(2772506476707, fulfillment_orders[0].get('order_id'))

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -44,13 +44,14 @@ class FulFillmentTest(TestCase):
 class FulfillmentOrdersTest(TestCase):
     def setUp(self):
         super(FulfillmentOrdersTest, self).setUp()
-        self.fake("fulfillment_orders/2558888935587", method='GET', body=self.load_fixture('fulfillment_orders'))
-        self.fake("orders/2772506476707/fulfillment_orders", method='GET', body=self.load_fixture('fulfillment_orders'))
 
     def test_get_fulfillment_orders(self):
+        self.fake("fulfillment_orders/2558888935587", method='GET', body=self.load_fixture('fulfillment_orders'))
         fulfillment_orders = shopify.FulfillmentOrders.find(2558888935587)
         self.assertEqual(2558888935587, fulfillment_orders.id)
 
     def test_get_order_fulfillment_orders(self):
+        self.fake("orders/2772506476707/fulfillment_orders", method='GET', body=self.load_fixture('fulfillment_orders'))
         fulfillment_orders = shopify.FulfillmentOrders.find(order_id=2772506476707)
         self.assertEqual(2772506476707, fulfillment_orders[0].get('order_id'))
+


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Currently, _FulfillmentOrders_ only hits the endpoint `GET /admin/api/2020-10/orders/{order_id}/fulfillment_orders.json`, but there is a second end point that isn't accessible. 
https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillmentorder

Fixes #420  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This change introduces the option to hit `GET /admin/api/2020-10/fulfillment_orders/{fulfillment_order_id}.json` by checking the arguments passed through. 

- If it contains a `fulfillment_order_id`, use endpoint `/admin/api/2020-10/fulfillment_orders/{fulfillment_order_id}.json`
- If it only contains an `order_id`,  use endpoint `orders/{order_id}/fulfillment_orders`
<!--
  Summary of the changes committed.
-->

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
