### PR TITLE
Add update_tracking endpoint to Fulfillment

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Added support for Fulfillment.update_tracking ([#432](https://github.com/Shopify/shopify_python_api/pull/432))
+
 == Version 8.2.0
 - [Feature] Add support for Dynamic API Versioning. When the library is initialized, it will now make a request to 
 Shopify to fetch a list of the available API versions. ([#441](https://github.com/Shopify/shopify_python_api/pull/441))

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -17,7 +17,7 @@ class Fulfillment(ShopifyResource):
     def update_tracking(self, tracking_info, notify_customer):
         fulfill = FulfillmentV2()
         fulfill.id = self.id
-        fulfill.update_tracking(tracking_info, notify_customer)
+        self._load_attributes_from_response(fulfill.update_tracking(tracking_info, notify_customer))
 
 
 class FulfillmentOrders(ShopifyResource):
@@ -34,4 +34,4 @@ class FulfillmentV2(ShopifyResource):
                 "notify_customer": notify_customer
             }
         }
-        self._load_attributes_from_response(self.post("update_tracking", json.dumps(body).encode()))
+        return self.post("update_tracking", json.dumps(body).encode())

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -1,4 +1,5 @@
 from ..base import ShopifyResource
+import json
 
 
 class Fulfillment(ShopifyResource):
@@ -13,6 +14,24 @@ class Fulfillment(ShopifyResource):
     def open(self):
         self._load_attributes_from_response(self.post("open"))
 
+    def update_tracking(self, tracking_info, notify_customer):
+        fulfill = FulfillmentV2()
+        fulfill.id = self.id
+        fulfill.update_tracking(tracking_info, notify_customer)
+
 
 class FulfillmentOrders(ShopifyResource):
     _prefix_source = "/orders/$order_id/"
+
+class FulfillmentV2(ShopifyResource):
+    _singular = 'fulfillment'
+    _plural = 'fulfillments'
+    
+    def update_tracking(self, tracking_info, notify_customer):
+        body = {
+            "fulfillment": {
+                "tracking_info": tracking_info,
+                "notify_customer": notify_customer
+            }
+        }
+        self._load_attributes_from_response(self.post("update_tracking", json.dumps(body).encode()))

--- a/test/fixtures/fulfillment.json
+++ b/test/fixtures/fulfillment.json
@@ -5,7 +5,7 @@
     "order_id": 450789469,
     "service": "manual",
     "status": "pending",
-    "tracking_company": null,
+    "tracking_company": "null-company",
     "updated_at": "2013-11-01T16:06:08-04:00",
     "tracking_number": "1Z2345",
     "tracking_numbers": [

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -3,7 +3,7 @@ from test.test_helper import TestCase
 from pyactiveresource.activeresource import ActiveResource
 
 class FulFillmentTest(TestCase):
-  
+
     def setUp(self):
         super(FulFillmentTest, self).setUp()
         self.fake("orders/450789469/fulfillments/255858046", method='GET', body=self.load_fixture('fulfillment'))
@@ -40,3 +40,24 @@ class FulFillmentTest(TestCase):
         self.assertEqual('pending', fulfillment.status)
         fulfillment.cancel()
         self.assertEqual('cancelled', fulfillment.status)
+
+    def test_update_tracking(self):
+        fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
+
+        tracking_info = { "number": 1111, "url": "http://www.my-url.com", "company": "my-company"}
+        notify_customer = False
+
+        update_tracking = self.load_fixture('fulfillment')
+        update_tracking = update_tracking.replace(b'null-company', b'my-company')
+        update_tracking = update_tracking.replace(b'http://www.google.com/search?q=1Z2345', b'http://www.my-url.com')
+        update_tracking = update_tracking.replace(b'1Z2345', b'1111')
+
+        self.fake("fulfillments/255858046/update_tracking", method="POST", headers={'Content-type': 'application/json'}, body=update_tracking)
+
+        self.assertEqual("null-company", fulfillment.tracking_company)
+        self.assertEqual("1Z2345", fulfillment.tracking_number)
+        self.assertEqual("http://www.google.com/search?q=1Z2345", fulfillment.tracking_url)
+        fulfillment.update_tracking(tracking_info, notify_customer)
+        self.assertEqual("my-company", fulfillment.tracking_company)
+        self.assertEqual('1111', fulfillment.tracking_number)
+        self.assertEqual('http://www.my-url.com', fulfillment.tracking_url)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
The fulfillment API has a clear method of [updating tracking information ](https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillment#update_tracking-2020-01) that our library doesn't support. 
This may help reduce issues such as #310.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Following the footsteps of shopify_api, a new class was created in order to hit the end point `/fulfillments/$fulfillment_id`
<!--
  Summary of the changes committed.
-->

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
