### PR TITLE
Dynamic api version

### DIFF
--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -24,11 +24,15 @@ class ApiVersion(object):
 
     @classmethod
     def define_known_versions(cls):
-        cls.define_version(Unstable())
-        cls.define_version(Release('2020-01'))
-        cls.define_version(Release('2020-04'))
-        cls.define_version(Release('2020-07'))
-        cls.define_version(Release('2020-10'))
+        req = request.urlopen("https://app.shopify.com/services/apis.json")
+        data = json.loads(req.read().decode("utf-8"))
+        for api in j['apis']:    
+            if api['handle'] == 'admin':
+                for release in api['versions']:
+                    if release == 'unstable':
+                        cls.define_version(Unstable())
+                    else:
+                        cls.define_version(Release(release)
 
     @classmethod
     def clear_defined_versions(cls):

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -1,4 +1,5 @@
 import re
+from six.moves.urllib import request
 
 
 class InvalidVersionError(Exception):

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -30,10 +30,10 @@ class ApiVersion(object):
         for api in j['apis']:    
             if api['handle'] == 'admin':
                 for release in api['versions']:
-                    if release == 'unstable':
+                    if release['handle'] == 'unstable':
                         cls.define_version(Unstable())
                     else:
-                        cls.define_version(Release(release))
+                        cls.define_version(Release(release['handle']))
 
     @classmethod
     def clear_defined_versions(cls):

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -33,7 +33,7 @@ class ApiVersion(object):
                     if release == 'unstable':
                         cls.define_version(Unstable())
                     else:
-                        cls.define_version(Release(release)
+                        cls.define_version(Release(release))
 
     @classmethod
     def clear_defined_versions(cls):

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -1,4 +1,5 @@
 import re
+import json
 from six.moves.urllib import request
 
 
@@ -27,7 +28,7 @@ class ApiVersion(object):
     def define_known_versions(cls):
         req = request.urlopen("https://app.shopify.com/services/apis.json")
         data = json.loads(req.read().decode("utf-8"))
-        for api in j['apis']:    
+        for api in data['apis']:    
             if api['handle'] == 'admin':
                 for release in api['versions']:
                     if release['handle'] == 'unstable':


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This PR will automatically populate with the current API versions supported for the Shopify Admin API.  

Hopefully, this should remove the requirement to manually update the list of current API versions.

Fixes <!-- link to issue if one exists -->
#339 
<!--
  Context about the problem that’s being addressed.
-->
Versioning has been here a while and it's probably time we fix this manual update requirement. A manual system is fine, but it still causes issues with development and to not be able to select the currently available APIs, that is to say, to have to wait for this package to be updated every quarter is unreasonable. It is now 25 November, Release Candidate 2021-01 has been available for also 2 months now and it is still not supported here.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
-->
`ApiVersion.define_known_versions()` has been changed to make a request to https://app.shopify.com/services/apis.json and automatically populate the `versions` list.


### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
