### PR TITLE
Mention activation charge changes in 2021-01 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _Note: Your application must be public to test the billing process. To test on a
     charge = shopify.ApplicationCharge.find(charge_id)
     shopify.ApplicationCharge.activate(charge)
     ```
-1.  Check that `activated_charge` status is `active` (This action is no longer necessary if the charge is created with [API version 2021-01 or later](https://shopify.dev/changelog/auto-activation-of-charges-and-subscriptions))
+1.  Check that `activated_charge` status is `active` (_Note: This action is no longer necessary if the charge is created with [API version 2021-01 or later](https://shopify.dev/changelog/auto-activation-of-charges-and-subscriptions)_)
     ```python
     activated_charge = shopify.ApplicationCharge.find(charge_id)
     has_been_billed = activated_charge.status == 'active'

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _Note: Your application must be public to test the billing process. To test on a
     charge = shopify.ApplicationCharge.find(charge_id)
     shopify.ApplicationCharge.activate(charge)
     ```
-1.  Check that `activated_charge` status is `active`
+1.  Check that `activated_charge` status is `active` (This action is no longer necessary if the charge is created with [API version 2021-01 or later](https://shopify.dev/changelog/auto-activation-of-charges-and-subscriptions))
     ```python
     activated_charge = shopify.ApplicationCharge.find(charge_id)
     has_been_billed = activated_charge.status == 'active'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #447 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Updating readme to indicate that charges no longer need to be manually activated in the new API version.
<!--
  Summary of the changes committed.
-->

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
