### PR TITLE
Fix 'object of type "filter" has no len()' issue in shopify_api.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 - Added support for Fulfillment.update_tracking ([#432](https://github.com/Shopify/shopify_python_api/pull/432))
 - Add FulfillmentEvent resource ([#454](https://github.com/Shopify/shopify_python_api/pull/454))
+- Fix for being unable to get the len() of a filter ([#456](https://github.com/Shopify/shopify_python_api/pull/456))
 
 == Version 8.2.0
 - [Feature] Add support for Dynamic API Versioning. When the library is initialized, it will now make a request to 

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -51,9 +51,9 @@ class TasksMeta(type):
 
         # Allow unambigious abbreviations of tasks
         if task not in cls._tasks:
-            matches = list(filter(lambda item: item.startswith(task), cls._tasks))
-            if len(matches) == 1:
-                task = matches[0]
+            matches = filter(lambda item: item.startswith(task), cls._tasks)
+            if len(list(matches)) == 1:
+                task = list(matches)[0]
             else:
                 sys.stderr.write('Could not find task "%s".\n' % (task))
 

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -51,7 +51,7 @@ class TasksMeta(type):
 
         # Allow unambigious abbreviations of tasks
         if task not in cls._tasks:
-            matches = filter(lambda item: item.startswith(task), cls._tasks)
+            matches = list(filter(lambda item: item.startswith(task), cls._tasks))
             if len(matches) == 1:
                 task = matches[0]
             else:

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -52,8 +52,9 @@ class TasksMeta(type):
         # Allow unambigious abbreviations of tasks
         if task not in cls._tasks:
             matches = filter(lambda item: item.startswith(task), cls._tasks)
-            if len(list(matches)) == 1:
-                task = list(matches)[0]
+            list_of_matches = list(matches)
+            if len(list_of_matches) == 1:
+                task = list_of_matches[0]
             else:
                 sys.stderr.write('Could not find task "%s".\n' % (task))
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #426 

- previously, the code tried to get the length and index of a `filter`
- if you print out a filter, it will look like this
```
>>> f
<filter object at 0x10b0cedc0>
```

- this filter object has no `len()` attribute
```
>>> len(f)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: object of type 'filter' has no len()
```


### WHAT is this pull request doing?
- by converting the filter into a list, we will be able to get the length and index of a filter

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
