### PR TITLE
Add autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,7 @@ repos:
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5.4
+    hooks:
+    -   id: autopep8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.autopep8]
+max_line_length = 120

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -12,6 +12,7 @@ import yaml
 import six
 from six.moves import input, map
 
+
 def start_interpreter(**variables):
     # add the current working directory to the sys paths
     sys.path.append(os.getcwd())
@@ -19,8 +20,10 @@ def start_interpreter(**variables):
     import readline
     console(variables).interact()
 
+
 class ConfigFileError(Exception):
     pass
+
 
 def usage(usage_string):
     """Decorator to add a usage string to a function"""
@@ -28,6 +31,7 @@ def usage(usage_string):
         func.usage = usage_string
         return func
     return decorate
+
 
 class TasksMeta(type):
     _prog = os.path.basename(sys.argv[0])
@@ -37,6 +41,7 @@ class TasksMeta(type):
 
         tasks = list(new_attrs.keys())
         tasks.append("help")
+
         def filter_func(item):
             return not item.startswith("_") and hasattr(getattr(cls, item), "__call__")
         tasks = filter(filter_func, tasks)
@@ -222,7 +227,6 @@ class Tasks(object):
         target = os.readlink(cls._default_symlink)
         return os.path.join(cls._shop_config_dir, target)
 
-
     @classmethod
     def _default_connection(cls):
         target = cls._default_connection_target()
@@ -252,6 +256,7 @@ class Tasks(object):
     @classmethod
     def _no_config_file_error(cls, filename):
         raise ConfigFileError("There is no config file at " + filename)
+
 
 try:
     Tasks.run_task(*sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
-NAME='ShopifyAPI'
+NAME = 'ShopifyAPI'
 exec(open('shopify/version.py').read())
-DESCRIPTION='Shopify API for Python'
-LONG_DESCRIPTION="""\
+DESCRIPTION = 'Shopify API for Python'
+LONG_DESCRIPTION = """\
 The ShopifyAPI library allows python developers to programmatically
 access the admin section of stores using an ActiveResource like
 interface similar the ruby Shopify API gem. The library makes HTTP
@@ -27,7 +27,7 @@ setup(name=NAME,
       ],
       test_suite='test',
       tests_require=[
-        'mock>=1.0.1',
+          'mock>=1.0.1',
       ],
       platforms='Any',
       classifiers=['Development Status :: 5 - Production/Stable',

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -2,11 +2,14 @@ import re
 import json
 from six.moves.urllib import request
 
+
 class InvalidVersionError(Exception):
     pass
 
+
 class VersionNotFoundError(Exception):
     pass
+
 
 class ApiVersion(object):
     versions = {}
@@ -76,7 +79,7 @@ class Unstable(ApiVersion):
     def __init__(self):
         self._name = 'unstable'
         self._numeric_version = 9000000
-        self._path =  '/admin/api/unstable'
+        self._path = '/admin/api/unstable'
 
     @property
     def stable(self):

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -2,6 +2,7 @@ from pyactiveresource.collection import Collection
 from six.moves.urllib.parse import urlparse, parse_qs
 import cgi
 
+
 class PaginatedCollection(Collection):
     """
     A subclass of Collection which allows cycling through pages of
@@ -141,6 +142,7 @@ class PaginatedIterator(object):
     ...
     # every page and the page items are iterated
     """
+
     def __init__(self, collection):
         if not isinstance(collection, PaginatedCollection):
             raise TypeError("PaginatedIterator expects a PaginatedCollection instance")

--- a/shopify/mixins.py
+++ b/shopify/mixins.py
@@ -1,5 +1,6 @@
 import shopify.resources
 
+
 class Countable(object):
 
     @classmethod

--- a/shopify/resources/api_permission.py
+++ b/shopify/resources/api_permission.py
@@ -1,5 +1,6 @@
 from ..base import ShopifyResource
 
+
 class ApiPermission(ShopifyResource):
 
     @classmethod

--- a/shopify/resources/application_credit.py
+++ b/shopify/resources/application_credit.py
@@ -1,4 +1,5 @@
 from ..base import ShopifyResource
 
+
 class ApplicationCredit(ShopifyResource):
     pass

--- a/shopify/resources/asset.py
+++ b/shopify/resources/asset.py
@@ -18,7 +18,7 @@ class Asset(ShopifyResource):
     def _element_path(cls, id, prefix_options={}, query_options=None):
         if query_options is None:
             prefix_options, query_options = cls._split_options(prefix_options)
-        return "%s%s.%s%s" % (cls._prefix(prefix_options)+'/', cls.plural,
+        return "%s%s.%s%s" % (cls._prefix(prefix_options) + '/', cls.plural,
                               cls.format.extension, cls._query_string(query_options))
 
     @classmethod

--- a/shopify/resources/collection_listing.py
+++ b/shopify/resources/collection_listing.py
@@ -1,5 +1,6 @@
 from ..base import ShopifyResource
 
+
 class CollectionListing(ShopifyResource):
     _primary_key = "collection_id"
 

--- a/shopify/resources/customer.py
+++ b/shopify/resources/customer.py
@@ -21,6 +21,6 @@ class Customer(ShopifyResource, mixins.Metafields):
         """
         return cls._build_collection(cls.get("search", **kwargs))
 
-    def send_invite(self, customer_invite = CustomerInvite()):
+    def send_invite(self, customer_invite=CustomerInvite()):
         resource = self.post("send_invite", customer_invite.encode())
         return CustomerInvite(Customer.format.decode(resource.body))

--- a/shopify/resources/discount_code.py
+++ b/shopify/resources/discount_code.py
@@ -1,4 +1,5 @@
 from ..base import ShopifyResource
 
+
 class DiscountCode(ShopifyResource):
     _prefix_source = "/price_rules/$price_rule_id/"

--- a/shopify/resources/discount_code_creation.py
+++ b/shopify/resources/discount_code_creation.py
@@ -1,6 +1,7 @@
 from ..base import ShopifyResource
 from .discount_code import DiscountCode
 
+
 class DiscountCodeCreation(ShopifyResource):
     _prefix_source = "/price_rules/$price_rule_id/"
 

--- a/shopify/resources/draft_order.py
+++ b/shopify/resources/draft_order.py
@@ -4,12 +4,12 @@ from .draft_order_invoice import DraftOrderInvoice
 
 
 class DraftOrder(ShopifyResource, mixins.Metafields):
-    def send_invoice(self, draft_order_invoice = DraftOrderInvoice()):
+    def send_invoice(self, draft_order_invoice=DraftOrderInvoice()):
         resource = self.post("send_invoice", draft_order_invoice.encode())
         return DraftOrderInvoice(DraftOrder.format.decode(resource.body))
 
-    def complete(self, params = {}):
+    def complete(self, params={}):
         if params.get('payment_pending', False):
-          self._load_attributes_from_response(self.put("complete", payment_pending='true'))
+            self._load_attributes_from_response(self.put("complete", payment_pending='true'))
         else:
-          self._load_attributes_from_response(self.put("complete"))
+            self._load_attributes_from_response(self.put("complete"))

--- a/shopify/resources/event.py
+++ b/shopify/resources/event.py
@@ -1,5 +1,6 @@
 from ..base import ShopifyResource
 
+
 class Event(ShopifyResource):
     _prefix_source = "/$resource/$resource_id/"
 

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -23,6 +23,7 @@ class Fulfillment(ShopifyResource):
 class FulfillmentOrders(ShopifyResource):
     _prefix_source = "/orders/$order_id/"
 
+
 class FulfillmentV2(ShopifyResource):
     _singular = 'fulfillment'
     _plural = 'fulfillments'

--- a/shopify/resources/fulfillment_event.py
+++ b/shopify/resources/fulfillment_event.py
@@ -1,5 +1,6 @@
 from ..base import ShopifyResource
 
+
 class FulfillmentEvent(ShopifyResource):
     _prefix_source = "/orders/$order_id/fulfillments/$fulfillment_id/"
     _singular = 'event'
@@ -15,7 +16,7 @@ class FulfillmentEvent(ShopifyResource):
             cls.site, order_id, fulfillment_id)
 
     def save(self):
-      status = self.attributes['status']
-      if status not in ['label_printed', 'label_purchased', 'attempted_delivery', 'ready_for_pickup', 'picked_up', 'confirmed', 'in_transit', 'out_for_delivery', 'delivered', 'failure']:
-        raise AttributeError("Invalid status")
-      return super(ShopifyResource, self).save()
+        status = self.attributes['status']
+        if status not in ['label_printed', 'label_purchased', 'attempted_delivery', 'ready_for_pickup', 'picked_up', 'confirmed', 'in_transit', 'out_for_delivery', 'delivered', 'failure']:
+            raise AttributeError("Invalid status")
+        return super(ShopifyResource, self).save()

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -3,6 +3,7 @@ from ..base import ShopifyResource
 from six.moves import urllib
 import json
 
+
 class GraphQL():
 
     def __init__(self):

--- a/shopify/resources/image.py
+++ b/shopify/resources/image.py
@@ -30,8 +30,8 @@ class Image(ShopifyResource):
     def metafields(self):
         if self.is_new():
             return []
-        query_params = { 'metafield[owner_id]': self.id, 'metafield[owner_resource]': 'product_image' }
-        return Metafield.find(from_ = '%s/metafields.json?%s' % (ShopifyResource.site, urllib.parse.urlencode(query_params)))
+        query_params = {'metafield[owner_id]': self.id, 'metafield[owner_resource]': 'product_image'}
+        return Metafield.find(from_='%s/metafields.json?%s' % (ShopifyResource.site, urllib.parse.urlencode(query_params)))
 
     def save(self):
         if 'product_id' not in self._prefix_options:

--- a/shopify/resources/inventory_level.py
+++ b/shopify/resources/inventory_level.py
@@ -13,7 +13,7 @@ class InventoryLevel(ShopifyResource):
         if query_options is None:
             prefix_options, query_options = cls._split_options(prefix_options)
 
-        return "%s%s.%s%s" % (cls._prefix(prefix_options)+'/', cls.plural,
+        return "%s%s.%s%s" % (cls._prefix(prefix_options) + '/', cls.plural,
                               cls.format.extension, cls._query_string(query_options))
 
     @classmethod

--- a/shopify/resources/line_item.py
+++ b/shopify/resources/line_item.py
@@ -2,5 +2,5 @@ from ..base import ShopifyResource
 
 
 class LineItem(ShopifyResource):
-  class Property(ShopifyResource):
-    pass
+    class Property(ShopifyResource):
+        pass

--- a/shopify/resources/location.py
+++ b/shopify/resources/location.py
@@ -1,6 +1,7 @@
 from ..base import ShopifyResource
 from .inventory_level import InventoryLevel
 
+
 class Location(ShopifyResource):
     def inventory_levels(self, **kwargs):
         return InventoryLevel.find(from_="%s/locations/%s/inventory_levels.json" % (

--- a/shopify/resources/marketing_event.py
+++ b/shopify/resources/marketing_event.py
@@ -1,7 +1,8 @@
 import json
 from ..base import ShopifyResource
 
+
 class MarketingEvent(ShopifyResource):
     def add_engagements(self, engagements):
-        engagements_json = json.dumps({ 'engagements': engagements })
+        engagements_json = json.dumps({'engagements': engagements})
         return self.post('engagements', engagements_json.encode())

--- a/shopify/resources/order_risk.py
+++ b/shopify/resources/order_risk.py
@@ -1,6 +1,7 @@
 from ..base import ShopifyResource
 
+
 class OrderRisk(ShopifyResource):
-  _prefix_source = "/orders/$order_id/"
-  _singular = "risk"
-  _plural = "risks"
+    _prefix_source = "/orders/$order_id/"
+    _singular = "risk"
+    _plural = "risks"

--- a/shopify/resources/policy.py
+++ b/shopify/resources/policy.py
@@ -2,5 +2,6 @@ from ..base import ShopifyResource
 from shopify import mixins
 import shopify
 
+
 class Policy(ShopifyResource, mixins.Metafields, mixins.Events):
-  pass
+    pass

--- a/shopify/resources/price_rule.py
+++ b/shopify/resources/price_rule.py
@@ -3,16 +3,17 @@ from ..base import ShopifyResource
 from .discount_code import DiscountCode
 from .discount_code_creation import DiscountCodeCreation
 
+
 class PriceRule(ShopifyResource):
-    def add_discount_code(self, discount_code = DiscountCode()):
+    def add_discount_code(self, discount_code=DiscountCode()):
         resource = self.post("discount_codes", discount_code.encode())
         return DiscountCode(PriceRule.format.decode(resource.body))
 
     def discount_codes(self):
         return DiscountCode.find(price_rule_id=self.id)
 
-    def create_batch(self, codes = []):
-        codes_json = json.dumps({ 'discount_codes': codes})
+    def create_batch(self, codes=[]):
+        codes_json = json.dumps({'discount_codes': codes})
 
         response = self.post("batch", codes_json.encode())
         return DiscountCodeCreation(PriceRule.format.decode(response.body))

--- a/shopify/resources/product_listing.py
+++ b/shopify/resources/product_listing.py
@@ -1,5 +1,6 @@
 from ..base import ShopifyResource
 
+
 class ProductListing(ShopifyResource):
     _primary_key = "product_id"
 

--- a/shopify/resources/recurring_application_charge.py
+++ b/shopify/resources/recurring_application_charge.py
@@ -1,6 +1,7 @@
 from ..base import ShopifyResource
 from .usage_charge import UsageCharge
 
+
 def _get_first_by_status(resources, status):
     for resource in resources:
         if resource.status == status:
@@ -14,7 +15,7 @@ class RecurringApplicationCharge(ShopifyResource):
         return UsageCharge.find(recurring_application_charge_id=self.id)
 
     def customize(self, **kwargs):
-        self._load_attributes_from_response(self.put("customize", recurring_application_charge= kwargs))
+        self._load_attributes_from_response(self.put("customize", recurring_application_charge=kwargs))
 
     @classmethod
     def current(cls):

--- a/shopify/resources/tender_transaction.py
+++ b/shopify/resources/tender_transaction.py
@@ -1,4 +1,5 @@
 from ..base import ShopifyResource
 
+
 class TenderTransaction(ShopifyResource):
     pass

--- a/shopify/resources/usage_charge.py
+++ b/shopify/resources/usage_charge.py
@@ -1,5 +1,6 @@
 from ..base import ShopifyResource
 
+
 class UsageCharge(ShopifyResource):
     _prefix_source = "/recurring_application_charge/$recurring_application_charge_id/"
 

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -12,8 +12,10 @@ from six.moves import urllib
 from shopify.api_version import ApiVersion, Release, Unstable
 import six
 
+
 class ValidationException(Exception):
     pass
+
 
 class Session(object):
     api_key = None
@@ -49,7 +51,8 @@ class Session(object):
 
     def create_permission_url(self, scope, redirect_uri, state=None):
         query_params = dict(client_id=self.api_key, scope=",".join(scope), redirect_uri=redirect_uri)
-        if state: query_params['state'] = state
+        if state:
+            query_params['state'] = state
         return "https://%s/admin/oauth/authorize?%s" % (self.url, urllib.parse.urlencode(query_params))
 
     def request_token(self, params):
@@ -148,7 +151,7 @@ class Session(object):
                     continue
 
                 if k.endswith('[]'):
-                    #foo[]=1&foo[]=2 has to be transformed as foo=["1", "2"] note the whitespace after comma
+                    # foo[]=1&foo[]=2 has to be transformed as foo=["1", "2"] note the whitespace after comma
                     k = k.rstrip('[]')
                     v = json.dumps(list(map(str, v)))
 

--- a/test/access_scope_test.py
+++ b/test/access_scope_test.py
@@ -1,11 +1,12 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class AccessScopeTest(TestCase):
 
-  def test_find_should_return_all_access_scopes(self):
-    self.fake('oauth/access_scopes', body=self.load_fixture('access_scopes'),
-        prefix='/admin')
-    scopes = shopify.AccessScope.find()
-    self.assertEqual(3, len(scopes))
-    self.assertEqual('read_products', scopes[0].handle)
+    def test_find_should_return_all_access_scopes(self):
+        self.fake('oauth/access_scopes', body=self.load_fixture('access_scopes'),
+            prefix='/admin')
+        scopes = shopify.AccessScope.find()
+        self.assertEqual(3, len(scopes))
+        self.assertEqual('read_products', scopes[0].handle)

--- a/test/api_permission_test.py
+++ b/test/api_permission_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class ApiPermissionTest(TestCase):
 
     def test_delete_api_permission(self):

--- a/test/application_credit_test.py
+++ b/test/application_credit_test.py
@@ -2,6 +2,7 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class ApplicationCreditTest(TestCase):
     def test_get_application_credit(self):
         self.fake('application_credits/445365009', method='GET', body=self.load_fixture('application_credit'), code=200)

--- a/test/article_test.py
+++ b/test/article_test.py
@@ -1,11 +1,13 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class ArticleTest(TestCase):
 
     def test_create_article(self):
-        self.fake("blogs/1008414260/articles", method='POST', body=self.load_fixture('article'), headers={'Content-type': 'application/json'})
-        article = shopify.Article({'blog_id':1008414260})
+        self.fake("blogs/1008414260/articles", method='POST', body=self.load_fixture('article'),
+                  headers={'Content-type': 'application/json'})
+        article = shopify.Article({'blog_id': 1008414260})
         article.save()
         self.assertEqual("First Post", article.title)
 
@@ -18,7 +20,8 @@ class ArticleTest(TestCase):
         self.fake('articles/6242736', method='GET', body=self.load_fixture('article'))
         article = shopify.Article.find(6242736)
 
-        self.fake('articles/6242736', method='PUT', body=self.load_fixture('article'), headers={'Content-type': 'application/json'})
+        self.fake('articles/6242736', method='PUT', body=self.load_fixture('article'),
+                  headers={'Content-type': 'application/json'})
         article.save()
 
     def test_get_articles(self):

--- a/test/asset_test.py
+++ b/test/asset_test.py
@@ -3,6 +3,7 @@ import base64
 import shopify
 from test.test_helper import TestCase
 
+
 class AssetTest(TestCase):
 
     def test_get_assets(self):
@@ -10,11 +11,13 @@ class AssetTest(TestCase):
         v = shopify.Asset.find()
 
     def test_get_asset(self):
-        self.fake("assets.json?asset%5Bkey%5D=templates%2Findex.liquid", extension=False, method='GET', body=self.load_fixture('asset'))
+        self.fake("assets.json?asset%5Bkey%5D=templates%2Findex.liquid",
+                  extension=False, method='GET', body=self.load_fixture('asset'))
         v = shopify.Asset.find('templates/index.liquid')
 
     def test_update_asset(self):
-        self.fake("assets.json?asset%5Bkey%5D=templates%2Findex.liquid", extension=False, method='GET', body=self.load_fixture('asset'))
+        self.fake("assets.json?asset%5Bkey%5D=templates%2Findex.liquid",
+                  extension=False, method='GET', body=self.load_fixture('asset'))
         v = shopify.Asset.find('templates/index.liquid')
 
         self.fake("assets", method='PUT', body=self.load_fixture('asset'), headers={'Content-type': 'application/json'})
@@ -22,28 +25,34 @@ class AssetTest(TestCase):
 
     def test_get_assets_namespaced(self):
         self.fake("themes/1/assets", method='GET', body=self.load_fixture('assets'))
-        v = shopify.Asset.find(theme_id = 1)
+        v = shopify.Asset.find(theme_id=1)
 
     def test_get_asset_namespaced(self):
-        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1", extension=False, method='GET', body=self.load_fixture('asset'))
+        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1",
+                  extension=False, method='GET', body=self.load_fixture('asset'))
         v = shopify.Asset.find('templates/index.liquid', theme_id=1)
 
     def test_update_asset_namespaced(self):
-        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1", extension=False, method='GET', body=self.load_fixture('asset'))
+        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1",
+                  extension=False, method='GET', body=self.load_fixture('asset'))
         v = shopify.Asset.find('templates/index.liquid', theme_id=1)
 
-        self.fake("themes/1/assets", method='PUT', body=self.load_fixture('asset'), headers={'Content-type': 'application/json'})
+        self.fake("themes/1/assets", method='PUT', body=self.load_fixture('asset'),
+                  headers={'Content-type': 'application/json'})
         v.save()
 
     def test_delete_asset_namespaced(self):
-        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1", extension=False, method='GET', body=self.load_fixture('asset'))
+        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1",
+                  extension=False, method='GET', body=self.load_fixture('asset'))
         v = shopify.Asset.find('templates/index.liquid', theme_id=1)
 
-        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid", extension=False, method='DELETE', body="{}")
+        self.fake("themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid",
+                  extension=False, method='DELETE', body="{}")
         v.destroy()
 
     def test_attach(self):
-        self.fake("themes/1/assets", method='PUT', body=self.load_fixture('asset'), headers={'Content-type': 'application/json'})
+        self.fake("themes/1/assets", method='PUT', body=self.load_fixture('asset'),
+                  headers={'Content-type': 'application/json'})
         attachment = b'dGVzdCBiaW5hcnkgZGF0YTogAAE='
         key = 'assets/test.jpeg'
         theme_id = 1

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -4,6 +4,7 @@ from pyactiveresource.activeresource import ActiveResource
 from mock import patch
 import threading
 
+
 class BaseTest(TestCase):
 
     @classmethod
@@ -69,7 +70,7 @@ class BaseTest(TestCase):
     def test_delete_should_send_custom_headers_with_request(self):
         shopify.ShopifyResource.activate_session(self.session1)
 
-        org_headers=shopify.ShopifyResource.headers
+        org_headers = shopify.ShopifyResource.headers
         shopify.ShopifyResource.set_headers({'X-Custom': 'abc'})
 
         with patch('shopify.ShopifyResource.connection.delete') as mock:

--- a/test/blog_test.py
+++ b/test/blog_test.py
@@ -1,9 +1,11 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class BlogTest(TestCase):
 
     def test_blog_creation(self):
-        self.fake('blogs', method='POST', code=202, body=self.load_fixture('blog'), headers={'Content-type': 'application/json'})
+        self.fake('blogs', method='POST', code=202, body=self.load_fixture(
+            'blog'), headers={'Content-type': 'application/json'})
         blog = shopify.Blog.create({'title': "Test Blog"})
         self.assertEqual("Test Blog", blog.title)

--- a/test/carrier_service_test.py
+++ b/test/carrier_service_test.py
@@ -1,9 +1,11 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CarrierServiceTest(TestCase):
     def test_create_new_carrier_service(self):
-        self.fake("carrier_services", method='POST', body=self.load_fixture('carrier_service'), headers={'Content-type': 'application/json'})
+        self.fake("carrier_services", method='POST', body=self.load_fixture(
+            'carrier_service'), headers={'Content-type': 'application/json'})
 
         carrier_service = shopify.CarrierService.create({'name': "Some Postal Service"})
         self.assertEqual("Some Postal Service", carrier_service.name)

--- a/test/cart_test.py
+++ b/test/cart_test.py
@@ -1,13 +1,14 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CartTest(TestCase):
 
-  def test_all_should_return_all_carts(self):
-    self.fake('carts')
-    carts = shopify.Cart.find()
-    self.assertEqual(2, len(carts))
-    self.assertEqual(2, carts[0].id)
-    self.assertEqual("3eed8183d4281db6ea82ee2b8f23e9cc", carts[0].token)
-    self.assertEqual(1, len(carts[0].line_items))
-    self.assertEqual('test', carts[0].line_items[0].title)
+    def test_all_should_return_all_carts(self):
+        self.fake('carts')
+        carts = shopify.Cart.find()
+        self.assertEqual(2, len(carts))
+        self.assertEqual(2, carts[0].id)
+        self.assertEqual("3eed8183d4281db6ea82ee2b8f23e9cc", carts[0].token)
+        self.assertEqual(1, len(carts[0].line_items))
+        self.assertEqual('test', carts[0].line_items[0].title)

--- a/test/checkout_test.py
+++ b/test/checkout_test.py
@@ -1,12 +1,13 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CheckoutTest(TestCase):
 
-  def test_all_should_return_all_checkouts(self):
-    self.fake('checkouts')
-    checkouts = shopify.Checkout.find()
-    self.assertEqual(1, len(checkouts))
-    self.assertEqual(450789469, checkouts[0].id)
-    self.assertEqual("2a1ace52255252df566af0faaedfbfa7", checkouts[0].token)
-    self.assertEqual(2, len(checkouts[0].line_items))
+    def test_all_should_return_all_checkouts(self):
+        self.fake('checkouts')
+        checkouts = shopify.Checkout.find()
+        self.assertEqual(1, len(checkouts))
+        self.assertEqual(450789469, checkouts[0].id)
+        self.assertEqual("2a1ace52255252df566af0faaedfbfa7", checkouts[0].token)
+        self.assertEqual(2, len(checkouts[0].line_items))

--- a/test/collection_listing_test.py
+++ b/test/collection_listing_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CollectionListingTest(TestCase):
 
     def test_get_collection_listings(self):
@@ -30,7 +31,8 @@ class CollectionListingTest(TestCase):
         self.assertEqual("Home page", collection_listing.title)
 
     def test_get_collection_listing_product_ids(self):
-        self.fake('collection_listings/1/product_ids', method='GET', code=200, body=self.load_fixture('collection_listing_product_ids'))
+        self.fake('collection_listings/1/product_ids', method='GET', code=200,
+                  body=self.load_fixture('collection_listing_product_ids'))
 
         collection_listing = shopify.CollectionListing()
         collection_listing.id = 1

--- a/test/collection_publication_test.py
+++ b/test/collection_publication_test.py
@@ -2,12 +2,13 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class CollectionPublicationTest(TestCase):
     def test_find_all_collection_publications(self):
         self.fake(
             'publications/55650051/collection_publications',
             method='GET',
-            body= self.load_fixture('collection_publications')
+            body=self.load_fixture('collection_publications')
         )
         collection_publications = shopify.CollectionPublication.find(publication_id=55650051)
 

--- a/test/currency_test.py
+++ b/test/currency_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CurrencyTest(TestCase):
 
     def test_get_currencies(self):

--- a/test/customer_saved_search_test.py
+++ b/test/customer_saved_search_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CustomerSavedSearchTest(TestCase):
 
     def setUp(self):
@@ -8,13 +9,15 @@ class CustomerSavedSearchTest(TestCase):
         self.load_customer_saved_search()
 
     def test_get_customers_from_customer_saved_search(self):
-        self.fake('customer_saved_searches/8899730/customers', body=self.load_fixture('customer_saved_search_customers'))
+        self.fake('customer_saved_searches/8899730/customers',
+                  body=self.load_fixture('customer_saved_search_customers'))
         self.assertEqual(1, len(self.customer_saved_search.customers()))
         self.assertEqual(112223902, self.customer_saved_search.customers()[0].id)
 
     def test_get_customers_from_customer_saved_search_with_params(self):
-        self.fake('customer_saved_searches/8899730/customers.json?limit=1', extension=False, body=self.load_fixture('customer_saved_search_customers'))
-        customers = self.customer_saved_search.customers(limit = 1)
+        self.fake('customer_saved_searches/8899730/customers.json?limit=1', extension=False,
+                  body=self.load_fixture('customer_saved_search_customers'))
+        customers = self.customer_saved_search.customers(limit=1)
         self.assertEqual(1, len(customers))
         self.assertEqual(112223902, customers[0].id)
 

--- a/test/customer_test.py
+++ b/test/customer_test.py
@@ -2,6 +2,7 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class CustomerTest(TestCase):
     def setUp(self):
         super(CustomerTest, self).setUp()
@@ -9,7 +10,8 @@ class CustomerTest(TestCase):
         self.customer = shopify.Customer.find(207119551)
 
     def test_create_customer(self):
-        self.fake("customers", method='POST', body=self.load_fixture('customer'), headers={'Content-type': 'application/json'})
+        self.fake("customers", method='POST', body=self.load_fixture(
+            'customer'), headers={'Content-type': 'application/json'})
         customer = shopify.Customer()
         customer.first_name = 'Bob'
         customer.last_name = 'Lastnameson'
@@ -26,7 +28,8 @@ class CustomerTest(TestCase):
         self.assertEqual("Bob", self.customer.first_name)
 
     def test_search(self):
-        self.fake("customers/search.json?query=Bob+country%3AUnited+States", extension=False, body=self.load_fixture('customers_search'))
+        self.fake("customers/search.json?query=Bob+country%3AUnited+States",
+                  extension=False, body=self.load_fixture('customers_search'))
 
         results = shopify.Customer.search(query='Bob country:United States')
         self.assertEqual('Bob', results[0].first_name)
@@ -34,7 +37,8 @@ class CustomerTest(TestCase):
     def test_send_invite_with_no_params(self):
         customer_invite_fixture = self.load_fixture('customer_invite')
         customer_invite = json.loads(customer_invite_fixture.decode("utf-8"))
-        self.fake('customers/207119551/send_invite', method='POST', body=customer_invite_fixture, headers={'Content-type': 'application/json'})
+        self.fake('customers/207119551/send_invite', method='POST',
+                  body=customer_invite_fixture, headers={'Content-type': 'application/json'})
         customer_invite_response = self.customer.send_invite()
         self.assertEqual(json.loads('{"customer_invite": {}}'), json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(customer_invite_response, shopify.CustomerInvite)
@@ -43,7 +47,8 @@ class CustomerTest(TestCase):
     def test_send_invite_with_params(self):
         customer_invite_fixture = self.load_fixture('customer_invite')
         customer_invite = json.loads(customer_invite_fixture.decode("utf-8"))
-        self.fake('customers/207119551/send_invite', method='POST', body=customer_invite_fixture, headers={'Content-type': 'application/json'})
+        self.fake('customers/207119551/send_invite', method='POST',
+                  body=customer_invite_fixture, headers={'Content-type': 'application/json'})
         customer_invite_response = self.customer.send_invite(shopify.CustomerInvite(customer_invite['customer_invite']))
         self.assertEqual(customer_invite, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(customer_invite_response, shopify.CustomerInvite)

--- a/test/discount_code_creation_test.py
+++ b/test/discount_code_creation_test.py
@@ -1,6 +1,7 @@
 from test.test_helper import TestCase
 import shopify
 
+
 class DiscountCodeCreationTest(TestCase):
     def test_find_batch_job_discount_codes(self):
         self.fake('price_rules/1213131', body=self.load_fixture('price_rule'))

--- a/test/discount_code_test.py
+++ b/test/discount_code_test.py
@@ -23,8 +23,9 @@ class DiscountCodeTest(TestCase):
         self.discount_code.save()
         self.assertEqual('BOGO',
                          json.loads(self.http.request.data.decode("utf-8"))["discount_code"]["code"]
-                        )
+                         )
+
     def test_delete_a_specific_discount_code(self):
-      self.fake('price_rules/1213131/discount_codes/34', method='DELETE', body='destroyed')
-      self.discount_code.destroy()
-      self.assertEqual('DELETE', self.http.request.get_method())
+        self.fake('price_rules/1213131/discount_codes/34', method='DELETE', body='destroyed')
+        self.discount_code.destroy()
+        self.assertEqual('DELETE', self.http.request.get_method())

--- a/test/draft_order_test.py
+++ b/test/draft_order_test.py
@@ -26,25 +26,30 @@ class DraftOrderTest(TestCase):
         self.assertEqual(16, draft_orders_count)
 
     def test_create_draft_order(self):
-        self.fake('draft_orders', method='POST', code=201, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
-        draft_order = shopify.DraftOrder.create({"line_items": [{ "quantity": 1, "variant_id": 39072856 }]})
-        self.assertEqual(json.loads('{"draft_order": {"line_items": [{"quantity": 1, "variant_id": 39072856}]}}'), json.loads(self.http.request.data.decode("utf-8")))
+        self.fake('draft_orders', method='POST', code=201, body=self.load_fixture(
+            'draft_order'), headers={'Content-type': 'application/json'})
+        draft_order = shopify.DraftOrder.create({"line_items": [{"quantity": 1, "variant_id": 39072856}]})
+        self.assertEqual(json.loads('{"draft_order": {"line_items": [{"quantity": 1, "variant_id": 39072856}]}}'), json.loads(
+            self.http.request.data.decode("utf-8")))
 
     def test_create_draft_order_202(self):
-        self.fake('draft_orders', method='POST', code=202, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
-        draft_order = shopify.DraftOrder.create({"line_items": [{ "quantity": 1, "variant_id": 39072856 }]})
+        self.fake('draft_orders', method='POST', code=202, body=self.load_fixture(
+            'draft_order'), headers={'Content-type': 'application/json'})
+        draft_order = shopify.DraftOrder.create({"line_items": [{"quantity": 1, "variant_id": 39072856}]})
         self.assertEqual(39072856, draft_order.line_items[0].variant_id)
 
     def test_update_draft_order(self):
         self.draft_order.note = 'Test new note'
-        self.fake('draft_orders/517119332', method='PUT', code=200, body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
+        self.fake('draft_orders/517119332', method='PUT', code=200,
+                  body=self.load_fixture('draft_order'), headers={'Content-type': 'application/json'})
         self.draft_order.save()
         self.assertEqual('Test new note', json.loads(self.http.request.data.decode("utf-8"))['draft_order']['note'])
 
     def test_send_invoice_with_no_params(self):
         draft_order_invoice_fixture = self.load_fixture('draft_order_invoice')
         draft_order_invoice = json.loads(draft_order_invoice_fixture.decode("utf-8"))
-        self.fake('draft_orders/517119332/send_invoice', method='POST', body=draft_order_invoice_fixture, headers={'Content-type': 'application/json'})
+        self.fake('draft_orders/517119332/send_invoice', method='POST',
+                  body=draft_order_invoice_fixture, headers={'Content-type': 'application/json'})
         draft_order_invoice_response = self.draft_order.send_invoice()
         self.assertEqual(json.loads('{"draft_order_invoice": {}}'), json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(draft_order_invoice_response, shopify.DraftOrderInvoice)
@@ -53,8 +58,10 @@ class DraftOrderTest(TestCase):
     def test_send_invoice_with_params(self):
         draft_order_invoice_fixture = self.load_fixture('draft_order_invoice')
         draft_order_invoice = json.loads(draft_order_invoice_fixture.decode("utf-8"))
-        self.fake('draft_orders/517119332/send_invoice', method='POST', body=draft_order_invoice_fixture, headers={'Content-type': 'application/json'})
-        draft_order_invoice_response = self.draft_order.send_invoice(shopify.DraftOrderInvoice(draft_order_invoice['draft_order_invoice']))
+        self.fake('draft_orders/517119332/send_invoice', method='POST',
+                  body=draft_order_invoice_fixture, headers={'Content-type': 'application/json'})
+        draft_order_invoice_response = self.draft_order.send_invoice(
+            shopify.DraftOrderInvoice(draft_order_invoice['draft_order_invoice']))
         self.assertEqual(draft_order_invoice, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(draft_order_invoice_response, shopify.DraftOrderInvoice)
         self.assertEqual(draft_order_invoice['draft_order_invoice']['to'], draft_order_invoice_response.to)
@@ -65,10 +72,13 @@ class DraftOrderTest(TestCase):
         self.assertEqual('DELETE', self.http.request.get_method())
 
     def test_add_metafields_to_draft_order(self):
-        self.fake('draft_orders/517119332/metafields', method='POST', code=201, body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
-        field = self.draft_order.add_metafield(shopify.Metafield({'namespace': 'contact', 'key': 'email', 'value': '123@example.com', 'value_type': 'string'}))
-        self.assertEqual(json.loads('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), json.loads(self.http.request.data.decode("utf-8")))
-        self.assertFalse (field.is_new())
+        self.fake('draft_orders/517119332/metafields', method='POST', code=201,
+                  body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
+        field = self.draft_order.add_metafield(shopify.Metafield(
+            {'namespace': 'contact', 'key': 'email', 'value': '123@example.com', 'value_type': 'string'}))
+        self.assertEqual(json.loads('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'),
+                         json.loads(self.http.request.data.decode("utf-8")))
+        self.assertFalse(field.is_new())
         self.assertEqual('contact', field.namespace)
         self.assertEqual('email', field.key)
         self.assertEqual('123@example.com', field.value)
@@ -83,7 +93,7 @@ class DraftOrderTest(TestCase):
     def test_complete_draft_order_with_no_params(self):
         completed_fixture = self.load_fixture('draft_order_completed')
         completed_draft = json.loads(completed_fixture.decode("utf-8"))['draft_order']
-        headers={'Content-type': 'application/json', 'Content-length': '0'}
+        headers = {'Content-type': 'application/json', 'Content-length': '0'}
         self.fake('draft_orders/517119332/complete', method='PUT', body=completed_fixture, headers=headers)
         self.draft_order.complete()
         self.assertEqual(completed_draft['status'], self.draft_order.status)

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class EventTest(TestCase):
     def test_prefix_uses_resource(self):
         prefix = shopify.Event._prefix(options={'resource': "orders", "resource_id": 42})

--- a/test/fulfillment_event_test.py
+++ b/test/fulfillment_event_test.py
@@ -1,22 +1,28 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class FulFillmentEventTest(TestCase):
     def test_get_fulfillment_event(self):
-        self.fake("orders/2776493818019/fulfillments/2608403447971/events", method='GET', body=self.load_fixture('fulfillment_event'))
+        self.fake("orders/2776493818019/fulfillments/2608403447971/events",
+                  method='GET', body=self.load_fixture('fulfillment_event'))
         fulfillment_event = shopify.FulfillmentEvent.find(order_id=2776493818019, fulfillment_id=2608403447971)
         self.assertEqual(1, len(fulfillment_event))
 
     def test_create_fulfillment_event(self):
-        self.fake("orders/2776493818019/fulfillments/2608403447971/events", method='POST', body=self.load_fixture('fulfillment_event'), headers={'Content-type': 'application/json'})
-        new_fulfillment_event = shopify.FulfillmentEvent({'order_id': '2776493818019', 'fulfillment_id': '2608403447971'})
+        self.fake("orders/2776493818019/fulfillments/2608403447971/events", method='POST',
+                  body=self.load_fixture('fulfillment_event'), headers={'Content-type': 'application/json'})
+        new_fulfillment_event = shopify.FulfillmentEvent(
+            {'order_id': '2776493818019', 'fulfillment_id': '2608403447971'})
         new_fulfillment_event.status = 'ready_for_pickup'
         new_fulfillment_event.save()
 
     def test_error_on_incorrect_status(self):
         with self.assertRaises(AttributeError):
-            self.fake("orders/2776493818019/fulfillments/2608403447971/events/12584341209251", method='GET', body=self.load_fixture('fulfillment_event'))
+            self.fake("orders/2776493818019/fulfillments/2608403447971/events/12584341209251",
+                      method='GET', body=self.load_fixture('fulfillment_event'))
             incorrect_status = 'asdf'
-            fulfillment_event = shopify.FulfillmentEvent.find(12584341209251, order_id='2776493818019', fulfillment_id='2608403447971')
+            fulfillment_event = shopify.FulfillmentEvent.find(
+                12584341209251, order_id='2776493818019', fulfillment_id='2608403447971')
             fulfillment_event.status = incorrect_status
             fulfillment_event.save()

--- a/test/fulfillment_service_test.py
+++ b/test/fulfillment_service_test.py
@@ -1,9 +1,11 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class FulfillmentServiceTest(TestCase):
     def test_create_new_fulfillment_service(self):
-        self.fake("fulfillment_services", method='POST', body=self.load_fixture('fulfillment_service'), headers={'Content-type': 'application/json'})
+        self.fake("fulfillment_services", method='POST', body=self.load_fixture(
+            'fulfillment_service'), headers={'Content-type': 'application/json'})
 
         fulfillment_service = shopify.FulfillmentService.create({'name': "SomeService"})
         self.assertEqual("SomeService", fulfillment_service.name)

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -2,6 +2,7 @@ import shopify
 from test.test_helper import TestCase
 from pyactiveresource.activeresource import ActiveResource
 
+
 class FulFillmentTest(TestCase):
 
     def setUp(self):
@@ -12,8 +13,9 @@ class FulFillmentTest(TestCase):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
         success = self.load_fixture('fulfillment')
-        success = success.replace(b'pending',b'open')
-        self.fake("orders/450789469/fulfillments/255858046/open", method='POST', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=success)
+        success = success.replace(b'pending', b'open')
+        self.fake("orders/450789469/fulfillments/255858046/open", method='POST',
+                  headers={'Content-length': '0', 'Content-type': 'application/json'}, body=success)
 
         self.assertEqual('pending', fulfillment.status)
         fulfillment.open()
@@ -23,8 +25,9 @@ class FulFillmentTest(TestCase):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
         success = self.load_fixture('fulfillment')
-        success = success.replace(b'pending',b'success')
-        self.fake("orders/450789469/fulfillments/255858046/complete", method='POST', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=success)
+        success = success.replace(b'pending', b'success')
+        self.fake("orders/450789469/fulfillments/255858046/complete", method='POST',
+                  headers={'Content-length': '0', 'Content-type': 'application/json'}, body=success)
 
         self.assertEqual('pending', fulfillment.status)
         fulfillment.complete()
@@ -35,7 +38,8 @@ class FulFillmentTest(TestCase):
 
         cancelled = self.load_fixture('fulfillment')
         cancelled = cancelled.replace(b'pending', b'cancelled')
-        self.fake("orders/450789469/fulfillments/255858046/cancel", method='POST', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=cancelled)
+        self.fake("orders/450789469/fulfillments/255858046/cancel", method='POST',
+                  headers={'Content-length': '0', 'Content-type': 'application/json'}, body=cancelled)
 
         self.assertEqual('pending', fulfillment.status)
         fulfillment.cancel()
@@ -44,7 +48,7 @@ class FulFillmentTest(TestCase):
     def test_update_tracking(self):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
-        tracking_info = { "number": 1111, "url": "http://www.my-url.com", "company": "my-company"}
+        tracking_info = {"number": 1111, "url": "http://www.my-url.com", "company": "my-company"}
         notify_customer = False
 
         update_tracking = self.load_fixture('fulfillment')
@@ -52,7 +56,8 @@ class FulFillmentTest(TestCase):
         update_tracking = update_tracking.replace(b'http://www.google.com/search?q=1Z2345', b'http://www.my-url.com')
         update_tracking = update_tracking.replace(b'1Z2345', b'1111')
 
-        self.fake("fulfillments/255858046/update_tracking", method="POST", headers={'Content-type': 'application/json'}, body=update_tracking)
+        self.fake("fulfillments/255858046/update_tracking", method="POST",
+                  headers={'Content-type': 'application/json'}, body=update_tracking)
 
         self.assertEqual("null-company", fulfillment.tracking_company)
         self.assertEqual("1Z2345", fulfillment.tracking_number)

--- a/test/gift_card_test.py
+++ b/test/gift_card_test.py
@@ -2,10 +2,12 @@ from decimal import Decimal
 import shopify
 from test.test_helper import TestCase
 
+
 class GiftCardTest(TestCase):
 
     def test_gift_card_creation(self):
-        self.fake('gift_cards', method='POST', code=202, body=self.load_fixture('gift_card'), headers={'Content-type': 'application/json'})
+        self.fake('gift_cards', method='POST', code=202, body=self.load_fixture(
+            'gift_card'), headers={'Content-type': 'application/json'})
         gift_card = shopify.GiftCard.create({'code': 'd7a2bcggda89c293', 'note': "Gift card note."})
         self.assertEqual("Gift card note.", gift_card.note)
         self.assertEqual("c293", gift_card.last_characters)
@@ -17,7 +19,8 @@ class GiftCardTest(TestCase):
 
     def test_disable_gift_card(self):
         self.fake('gift_cards/4208208', method='GET', code=200, body=self.load_fixture('gift_card'))
-        self.fake('gift_cards/4208208/disable', method='POST', code=200, body=self.load_fixture('gift_card_disabled'), headers={'Content-length': '0', 'Content-type': 'application/json'})
+        self.fake('gift_cards/4208208/disable', method='POST', code=200, body=self.load_fixture('gift_card_disabled'),
+                  headers={'Content-length': '0', 'Content-type': 'application/json'})
         gift_card = shopify.GiftCard.find(4208208)
         self.assertFalse(gift_card.disabled_at)
         gift_card.disable()
@@ -25,7 +28,8 @@ class GiftCardTest(TestCase):
 
     def test_adjust_gift_card(self):
         self.fake('gift_cards/4208208', method='GET', code=200, body=self.load_fixture('gift_card'))
-        self.fake('gift_cards/4208208/adjustments', method='POST', code=201, body=self.load_fixture('gift_card_adjustment'), headers={'Content-type': 'application/json'})
+        self.fake('gift_cards/4208208/adjustments', method='POST', code=201,
+                  body=self.load_fixture('gift_card_adjustment'), headers={'Content-type': 'application/json'})
         gift_card = shopify.GiftCard.find(4208208)
         self.assertEqual(gift_card.balance, "25.00")
         adjustment = gift_card.add_adjustment(shopify.GiftCardAdjustment({
@@ -35,7 +39,8 @@ class GiftCardTest(TestCase):
         self.assertEqual(Decimal(adjustment.amount), Decimal("100"))
 
     def test_search(self):
-        self.fake("gift_cards/search.json?query=balance%3A10", extension=False, body=self.load_fixture('gift_cards_search'))
+        self.fake("gift_cards/search.json?query=balance%3A10",
+                  extension=False, body=self.load_fixture('gift_cards_search'))
 
         results = shopify.GiftCard.search(query='balance:10')
         self.assertEqual(results[0].balance, "10.00")

--- a/test/graphql_test.py
+++ b/test/graphql_test.py
@@ -2,6 +2,7 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class GraphQLTest(TestCase):
 
     def setUp(self):
@@ -18,7 +19,7 @@ class GraphQLTest(TestCase):
                 'X-Shopify-Access-Token': 'token',
                 'Accept': 'application/json',
                 'Content-Type': 'application/json'
-                })
+            })
         query = '''
             {
                 shop {
@@ -28,7 +29,6 @@ class GraphQLTest(TestCase):
             }
         '''
         self.result = client.execute(query)
-
 
     def test_fetch_shop_with_graphql(self):
         self.assertTrue(json.loads(self.result)['shop']['name'] == 'Apple Computers')

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -2,11 +2,13 @@ import shopify
 from test.test_helper import TestCase
 import base64
 
+
 class ImageTest(TestCase):
 
     def test_create_image(self):
-        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})
-        image = shopify.Image({'product_id':632910392})
+        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'),
+                  headers={'Content-type': 'application/json'})
+        image = shopify.Image({'product_id': 632910392})
         image.position = 1
         image.attachment = "R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf=="
         image.save()
@@ -15,10 +17,12 @@ class ImageTest(TestCase):
         self.assertEqual(850703190, image.id)
 
     def test_attach_image(self):
-        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})
-        image = shopify.Image({'product_id':632910392})
+        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'),
+                  headers={'Content-type': 'application/json'})
+        image = shopify.Image({'product_id': 632910392})
         image.position = 1
-        binary_in = base64.b64decode("R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf==")
+        binary_in = base64.b64decode(
+            "R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf==")
         image.attach_image(data=binary_in, filename='ipod-nano.png')
         image.save()
         binary_out = base64.b64decode(image.attachment)
@@ -28,7 +32,8 @@ class ImageTest(TestCase):
         self.assertEqual(binary_in, binary_out)
 
     def test_create_image_then_add_parent_id(self):
-        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'), headers={'Content-type': 'application/json'})
+        self.fake("products/632910392/images", method='POST', body=self.load_fixture('image'),
+                  headers={'Content-type': 'application/json'})
         image = shopify.Image()
         image.position = 1
         image.product_id = 632910392
@@ -52,7 +57,7 @@ class ImageTest(TestCase):
         fake_extension = 'json?metafield[owner_id]=850703190&metafield[owner_resource]=product_image'
         self.fake("metafields", method='GET', extension=fake_extension, body=self.load_fixture('image_metafields'))
 
-        image = shopify.Image(attributes = { 'id': 850703190, 'product_id': 632910392 })
+        image = shopify.Image(attributes={'id': 850703190, 'product_id': 632910392})
         metafields = image.metafields()
 
         self.assertEqual(1, len(metafields))

--- a/test/inventory_item_test.py
+++ b/test/inventory_item_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class InventoryItemTest(TestCase):
 
     def test_fetch_inventory_item(self):

--- a/test/inventory_level_test.py
+++ b/test/inventory_level_test.py
@@ -3,6 +3,7 @@ import json
 from six.moves.urllib.parse import urlencode
 from test.test_helper import TestCase
 
+
 class InventoryLevelTest(TestCase):
 
     def test_fetch_inventory_level(self):
@@ -19,7 +20,8 @@ class InventoryLevelTest(TestCase):
             location_ids='905684977,487838322'
         )
         self.assertTrue(
-            all(item.location_id in params['location_ids'] and item.inventory_item_id in params['inventory_item_ids'] for item in inventory_levels)
+            all(item.location_id in params['location_ids']
+                and item.inventory_item_id in params['inventory_item_ids'] for item in inventory_levels)
         )
 
     def test_inventory_level_adjust(self):

--- a/test/location_test.py
+++ b/test/location_test.py
@@ -2,20 +2,21 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class LocationTest(TestCase):
     def test_fetch_locations(self):
         self.fake("locations", method='GET', body=self.load_fixture('locations'))
         locations = shopify.Location.find()
-        self.assertEqual(2,len(locations))
+        self.assertEqual(2, len(locations))
 
     def test_fetch_location(self):
         self.fake("locations/487838322", method='GET', body=self.load_fixture('location'))
         location = shopify.Location.find(487838322)
-        self.assertEqual(location.id,487838322)
-        self.assertEqual(location.name,"Fifth Avenue AppleStore")
+        self.assertEqual(location.id, 487838322)
+        self.assertEqual(location.name, "Fifth Avenue AppleStore")
 
     def test_inventory_levels_returns_all_inventory_levels(self):
-        location = shopify.Location({'id':487838322})
+        location = shopify.Location({'id': 487838322})
 
         self.fake(
             "locations/%s/inventory_levels" % location.id,

--- a/test/marketing_event_test.py
+++ b/test/marketing_event_test.py
@@ -18,7 +18,8 @@ class MarketingEventTest(TestCase):
         self.assertEqual(len(marketing_events), 2)
 
     def test_create_marketing_event(self):
-        self.fake('marketing_events', method='POST', body=self.load_fixture('marketing_event'), headers={ 'Content-type': 'application/json' })
+        self.fake('marketing_events', method='POST', body=self.load_fixture(
+            'marketing_event'), headers={'Content-type': 'application/json'})
 
         marketing_event = shopify.MarketingEvent()
         marketing_event.currency_code = 'GBP'
@@ -41,7 +42,8 @@ class MarketingEventTest(TestCase):
 
     def test_update_marketing_event(self):
         self.fake('marketing_events/1', method='GET', code=200, body=self.load_fixture('marketing_event'))
-        self.fake('marketing_events/1', method='PUT', code=200, body=self.load_fixture('marketing_event'), headers={'Content-type': 'application/json'})
+        self.fake('marketing_events/1', method='PUT', code=200,
+                  body=self.load_fixture('marketing_event'), headers={'Content-type': 'application/json'})
 
         marketing_event = shopify.MarketingEvent.find(1)
         marketing_event.currency = 'USD'
@@ -56,11 +58,11 @@ class MarketingEventTest(TestCase):
     def test_add_engagements(self):
         self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
         self.fake(
-          'marketing_events/1/engagements',
-          method='POST',
-          code=201,
-          body=self.load_fixture('engagement'),
-          headers={'Content-type': 'application/json'}
+            'marketing_events/1/engagements',
+            method='POST',
+            code=201,
+            body=self.load_fixture('engagement'),
+            headers={'Content-type': 'application/json'}
         )
 
         marketing_event = shopify.MarketingEvent.find(1)

--- a/test/order_risk_test.py
+++ b/test/order_risk_test.py
@@ -1,42 +1,45 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class OrderRiskTest(TestCase):
 
-  def test_create_order_risk(self):
-    self.fake("orders/450789469/risks", method='POST', body= self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
-    v = shopify.OrderRisk({'order_id':450789469})
-    v.message = "This order was placed from a proxy IP"
-    v.recommendation = "cancel"
-    v.score = "1.0"
-    v.source = "External"
-    v.merchant_message = "This order was placed from a proxy IP"
-    v.display = True
-    v.cause_cancel = True
-    v.save()
+    def test_create_order_risk(self):
+        self.fake("orders/450789469/risks", method='POST', body=self.load_fixture('order_risk'),
+                  headers={'Content-type': 'application/json'})
+        v = shopify.OrderRisk({'order_id': 450789469})
+        v.message = "This order was placed from a proxy IP"
+        v.recommendation = "cancel"
+        v.score = "1.0"
+        v.source = "External"
+        v.merchant_message = "This order was placed from a proxy IP"
+        v.display = True
+        v.cause_cancel = True
+        v.save()
 
-    self.assertEqual(284138680, v.id)
+        self.assertEqual(284138680, v.id)
 
-  def test_get_order_risks(self):
-    self.fake("orders/450789469/risks", method='GET', body= self.load_fixture('order_risks'))
-    v = shopify.OrderRisk.find(order_id=450789469)
-    self.assertEqual(2, len(v))
+    def test_get_order_risks(self):
+        self.fake("orders/450789469/risks", method='GET', body=self.load_fixture('order_risks'))
+        v = shopify.OrderRisk.find(order_id=450789469)
+        self.assertEqual(2, len(v))
 
-  def test_get_order_risk(self):
-    self.fake("orders/450789469/risks/284138680", method='GET', body= self.load_fixture('order_risk'))
-    v = shopify.OrderRisk.find(284138680, order_id=450789469)
-    self.assertEqual(284138680, v.id)
+    def test_get_order_risk(self):
+        self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
+        v = shopify.OrderRisk.find(284138680, order_id=450789469)
+        self.assertEqual(284138680, v.id)
 
-  def test_delete_order_risk(self):
-    self.fake("orders/450789469/risks/284138680", method='GET', body= self.load_fixture('order_risk'))
-    self.fake("orders/450789469/risks/284138680", method='DELETE', body="destroyed")
-    v = shopify.OrderRisk.find(284138680, order_id=450789469)
-    v.destroy()
+    def test_delete_order_risk(self):
+        self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
+        self.fake("orders/450789469/risks/284138680", method='DELETE', body="destroyed")
+        v = shopify.OrderRisk.find(284138680, order_id=450789469)
+        v.destroy()
 
-  def test_delete_order_risk(self):
-    self.fake("orders/450789469/risks/284138680", method='GET', body= self.load_fixture('order_risk'))
-    self.fake("orders/450789469/risks/284138680", method='PUT', body= self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
+    def test_delete_order_risk(self):
+        self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
+        self.fake("orders/450789469/risks/284138680", method='PUT',
+                  body=self.load_fixture('order_risk'), headers={'Content-type': 'application/json'})
 
-    v = shopify.OrderRisk.find(284138680, order_id=450789469)
-    v.position = 3
-    v.save()
+        v = shopify.OrderRisk.find(284138680, order_id=450789469)
+        v.position = 3
+        v.save()

--- a/test/order_test.py
+++ b/test/order_test.py
@@ -3,6 +3,7 @@ from test.test_helper import TestCase
 from pyactiveresource.activeresource import ActiveResource
 from pyactiveresource.util import xml_to_dict
 
+
 class OrderTest(TestCase):
 
     def test_should_be_loaded_correctly_from_order_xml(self):

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -2,6 +2,7 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class PaginationTest(TestCase):
 
     def setUp(self):
@@ -17,15 +18,15 @@ class PaginationTest(TestCase):
 
         self.fake("products",
                   url=prefix + "/products.json?limit=2",
-                  body=json.dumps({ "products": fixture[:2] }),
+                  body=json.dumps({"products": fixture[:2]}),
                   response_headers=next_headers)
         self.fake("products",
                   url=prefix + "/products.json?limit=2&page_info=FOOBAR",
-                  body=json.dumps({ "products": fixture[2:4] }),
+                  body=json.dumps({"products": fixture[2:4]}),
                   response_headers=prev_headers)
         self.fake("products",
                   url=prefix + "/products.json?limit=2&page_info=BAZQUUX",
-                  body=json.dumps({ "products": fixture[:2] }),
+                  body=json.dumps({"products": fixture[:2]}),
                   response_headers=next_headers)
 
     def test_nonpaginates_collection(self):
@@ -33,7 +34,8 @@ class PaginationTest(TestCase):
         draft_orders = shopify.DraftOrder.find()
         self.assertEqual(1, len(draft_orders))
         self.assertEqual(517119332, draft_orders[0].id)
-        self.assertIsInstance(draft_orders, shopify.collection.PaginatedCollection, "find() result is not PaginatedCollection")
+        self.assertIsInstance(draft_orders, shopify.collection.PaginatedCollection,
+                              "find() result is not PaginatedCollection")
 
     def test_paginated_collection(self):
         items = shopify.Product.find(limit=2)
@@ -67,7 +69,7 @@ class PaginationTest(TestCase):
 
         self.assertIsInstance(p, shopify.collection.PaginatedCollection,
                               "previous_page() result is not PaginatedCollection")
-        self.assertEqual(len(p), 4, # cached
+        self.assertEqual(len(p), 4,  # cached
                          "previous_page() collection has incorrect length")
         self.assertIn("pagination", p.metadata)
         self.assertIn("next", p.metadata["pagination"],

--- a/test/price_rules_test.py
+++ b/test/price_rules_test.py
@@ -26,10 +26,10 @@ class PriceRuleTest(TestCase):
 
     def test_update_price_rule(self):
         self.price_rule.title = "Buy One Get One"
-        self.fake('price_rules/1213131', method='PUT', code=200, body=self.load_fixture('price_rule'), headers={'Content-type': 'application/json'})
+        self.fake('price_rules/1213131', method='PUT', code=200,
+                  body=self.load_fixture('price_rule'), headers={'Content-type': 'application/json'})
         self.price_rule.save()
         self.assertEqual('Buy One Get One', json.loads(self.http.request.data.decode("utf-8"))['price_rule']['title'])
-
 
     def test_delete_price_rule(self):
         self.fake('price_rules/1213131', method='DELETE', body='destroyed')
@@ -56,7 +56,8 @@ class PriceRuleTest(TestCase):
         self.assertEqual("line_item", price_rule.target_type)
 
     def test_get_discount_codes(self):
-        self.fake('price_rules/1213131/discount_codes', method='GET', code=200, body=self.load_fixture('discount_codes'))
+        self.fake('price_rules/1213131/discount_codes', method='GET',
+                  code=200, body=self.load_fixture('discount_codes'))
         discount_codes = self.price_rule.discount_codes()
         self.assertEqual(1, len(discount_codes))
 
@@ -67,7 +68,8 @@ class PriceRuleTest(TestCase):
                   method='POST',
                   body=price_rule_discount_fixture,
                   headers={'Content-type': 'application/json'})
-        price_rule_discount_response = self.price_rule.add_discount_code(shopify.DiscountCode(discount_code['discount_code']))
+        price_rule_discount_response = self.price_rule.add_discount_code(
+            shopify.DiscountCode(discount_code['discount_code']))
         self.assertEqual(discount_code, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(price_rule_discount_response, shopify.DiscountCode)
         self.assertEqual(discount_code['discount_code']['code'], price_rule_discount_response.code)

--- a/test/product_listing_test.py
+++ b/test/product_listing_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class ProductListingTest(TestCase):
 
     def test_get_product_listings(self):
@@ -29,7 +30,8 @@ class ProductListingTest(TestCase):
         self.assertEqual("Synergistic Silk Chair", product_listing.title)
 
     def test_get_product_listing_product_ids(self):
-        self.fake('product_listings/product_ids', method='GET', status = 200, body=self.load_fixture('product_listing_product_ids'))
+        self.fake('product_listings/product_ids', method='GET', status=200,
+                  body=self.load_fixture('product_listing_product_ids'))
 
         product_ids = shopify.ProductListing.product_ids()
 

--- a/test/product_publication_test.py
+++ b/test/product_publication_test.py
@@ -2,12 +2,13 @@ import shopify
 import json
 from test.test_helper import TestCase
 
+
 class ProductPublicationTest(TestCase):
     def test_find_all_product_publications(self):
         self.fake(
             'publications/55650051/product_publications',
             method='GET',
-            body= self.load_fixture('product_publications')
+            body=self.load_fixture('product_publications')
         )
         product_publications = shopify.ProductPublication.find(publication_id=55650051)
 

--- a/test/product_test.py
+++ b/test/product_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class ProductTest(TestCase):
 
     def setUp(self):
@@ -10,9 +11,11 @@ class ProductTest(TestCase):
         self.product = shopify.Product.find(632910392)
 
     def test_add_metafields_to_product(self):
-        self.fake("products/632910392/metafields", method='POST', code=201, body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
+        self.fake("products/632910392/metafields", method='POST', code=201,
+                  body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
 
-        field = self.product.add_metafield(shopify.Metafield({'namespace': "contact", 'key': "email", 'value': "123@example.com", 'value_type': "string"}))
+        field = self.product.add_metafield(shopify.Metafield(
+            {'namespace': "contact", 'key': "email", 'value': "123@example.com", 'value_type': "string"}))
 
         self.assertFalse(field.is_new())
         self.assertEqual("contact", field.namespace)
@@ -43,7 +46,8 @@ class ProductTest(TestCase):
         self.assertEqual(2, metafields_count)
 
     def test_get_metafields_for_product_count_with_params(self):
-        self.fake("products/632910392/metafields/count.json?value_type=string", extension=False, body=self.load_fixture('metafields_count'))
+        self.fake("products/632910392/metafields/count.json?value_type=string",
+                  extension=False, body=self.load_fixture('metafields_count'))
 
         metafields_count = self.product.metafields_count(value_type="string")
         self.assertEqual(2, metafields_count)
@@ -56,7 +60,9 @@ class ProductTest(TestCase):
         variant.save
 
     def test_add_variant_to_product(self):
-        self.fake("products/632910392/variants", method='POST', body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
-        self.fake("products/632910392/variants/808950810", method='PUT', code=200, body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
+        self.fake("products/632910392/variants", method='POST',
+                  body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
+        self.fake("products/632910392/variants/808950810", method='PUT', code=200,
+                  body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
         v = shopify.Variant()
         self.assertTrue(self.product.add_variant(v))

--- a/test/publication_test.py
+++ b/test/publication_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class PublicationTest(TestCase):
     def test_find_all_publications(self):
         self.fake('publications')

--- a/test/recurring_charge_test.py
+++ b/test/recurring_charge_test.py
@@ -1,10 +1,12 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class RecurringApplicationChargeTest(TestCase):
     def test_activate_charge(self):
         # Just check that calling activate doesn't raise an exception.
-        self.fake("recurring_application_charges/35463/activate", method='POST',headers={'Content-length':'0', 'Content-type': 'application/json'}, body=" ")
+        self.fake("recurring_application_charges/35463/activate", method='POST',
+                  headers={'Content-length': '0', 'Content-type': 'application/json'}, body=" ")
         charge = shopify.RecurringApplicationCharge({'id': 35463})
         charge.activate()
 
@@ -26,7 +28,8 @@ class RecurringApplicationChargeTest(TestCase):
         self.fake("recurring_application_charges")
         charge = shopify.RecurringApplicationCharge.current()
 
-        self.fake("recurring_application_charges/455696195/usage_charges", method='GET', body=self.load_fixture('usage_charges'))
+        self.fake("recurring_application_charges/455696195/usage_charges",
+                  method='GET', body=self.load_fixture('usage_charges'))
         usage_charges = charge.usage_charges()
         self.assertEqual(len(usage_charges), 2)
 
@@ -35,8 +38,9 @@ class RecurringApplicationChargeTest(TestCase):
         charge = shopify.RecurringApplicationCharge.current()
         self.assertEqual(charge.capped_amount, 100)
 
-        self.fake("recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200", extension=False, method='PUT', headers={'Content-length':'0', 'Content-type': 'application/json'}, body=self.load_fixture('recurring_application_charge_adjustment'))
-        charge.customize(capped_amount= 200)
+        self.fake("recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200", extension=False, method='PUT',
+                  headers={'Content-length': '0', 'Content-type': 'application/json'}, body=self.load_fixture('recurring_application_charge_adjustment'))
+        charge.customize(capped_amount=200)
         self.assertTrue(charge.update_capped_amount_url)
 
     def test_destroy_recurring_application_charge(self):

--- a/test/refund_test.py
+++ b/test/refund_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class RefundTest(TestCase):
     def setUp(self):
         super(RefundTest, self).setUp()

--- a/test/report_test.py
+++ b/test/report_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class CustomerSavedSearchTest(TestCase):
 
     def test_get_report(self):

--- a/test/resource_feedback_test.py
+++ b/test/resource_feedback_test.py
@@ -2,9 +2,10 @@ import json
 import shopify
 from test.test_helper import TestCase
 
+
 class ResourceFeedbackTest(TestCase):
     def test_get_resource_feedback(self):
-        body = json.dumps({ 'resource_feedback': [ { 'resource_type': 'Shop' } ] })
+        body = json.dumps({'resource_feedback': [{'resource_type': 'Shop'}]})
         self.fake('resource_feedback', method='GET', body=body)
 
         feedback = shopify.ResourceFeedback.find()
@@ -12,15 +13,15 @@ class ResourceFeedbackTest(TestCase):
         self.assertEqual('Shop', feedback[0].resource_type)
 
     def test_save_with_resource_feedback_endpoint(self):
-        body = json.dumps({ 'resource_feedback': {} })
-        self.fake('resource_feedback', method='POST', body=body, headers={ 'Content-Type': 'application/json' })
+        body = json.dumps({'resource_feedback': {}})
+        self.fake('resource_feedback', method='POST', body=body, headers={'Content-Type': 'application/json'})
 
         shopify.ResourceFeedback().save()
 
         self.assertEqual(body, self.http.request.data.decode("utf-8"))
 
     def test_get_resource_feedback_with_product_id(self):
-        body = json.dumps({ 'resource_feedback': [ { 'resource_type': 'Product' } ] })
+        body = json.dumps({'resource_feedback': [{'resource_type': 'Product'}]})
         self.fake('products/42/resource_feedback', method='GET', body=body)
 
         feedback = shopify.ResourceFeedback.find(product_id=42)
@@ -28,10 +29,11 @@ class ResourceFeedbackTest(TestCase):
         self.assertEqual('Product', feedback[0].resource_type)
 
     def test_save_with_product_id_resource_feedback_endpoint(self):
-        body = json.dumps({ 'resource_feedback': {} })
-        self.fake('products/42/resource_feedback', method='POST', body=body, headers={ 'Content-Type': 'application/json' })
+        body = json.dumps({'resource_feedback': {}})
+        self.fake('products/42/resource_feedback', method='POST',
+                  body=body, headers={'Content-Type': 'application/json'})
 
-        feedback = shopify.ResourceFeedback({'product_id':42})
+        feedback = shopify.ResourceFeedback({'product_id': 42})
         feedback.save()
 
         self.assertEqual(body, self.http.request.data.decode("utf-8"))

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -6,6 +6,7 @@ import time
 from six.moves import urllib
 from six import u
 
+
 class SessionTest(TestCase):
 
     @classmethod
@@ -40,7 +41,7 @@ class SessionTest(TestCase):
     def test_raise_error_if_params_passed_but_signature_omitted(self):
         with self.assertRaises(shopify.ValidationException):
             session = shopify.Session("testshop.myshopify.com", 'unstable')
-            token = session.request_token({'code':'any_code', 'foo': 'bar', 'timestamp':'1234'})
+            token = session.request_token({'code': 'any_code', 'foo': 'bar', 'timestamp': '1234'})
 
     def test_setup_api_key_and_secret_for_all_sessions(self):
         shopify.Session.setup(api_key="My test key", secret="My test secret")
@@ -91,43 +92,49 @@ class SessionTest(TestCase):
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
         scope = ["write_products"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products", self.normalize_url(permission_url))
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products",
+                         self.normalize_url(permission_url))
 
     def test_create_permission_url_returns_correct_url_with_dual_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
-        scope = ["write_products","write_customers"]
+        scope = ["write_products", "write_customers"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products%2Cwrite_customers", self.normalize_url(permission_url))
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_products%2Cwrite_customers",
+                         self.normalize_url(permission_url))
 
     def test_create_permission_url_returns_correct_url_with_no_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
         scope = []
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=", self.normalize_url(permission_url))
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=",
+                         self.normalize_url(permission_url))
 
     def test_create_permission_url_returns_correct_url_with_no_scope_and_redirect_uri_and_state(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
         scope = []
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com", state="mystate")
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=&state=mystate", self.normalize_url(permission_url))
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=&state=mystate",
+                         self.normalize_url(permission_url))
 
     def test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri_and_state(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
         scope = ["write_customers"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com", state="mystate")
-        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_customers&state=mystate", self.normalize_url(permission_url))
+        self.assertEqual("https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=my_redirect_uri.com&scope=write_customers&state=mystate",
+                         self.normalize_url(permission_url))
 
     def test_raise_exception_if_code_invalid_in_request_token(self):
         shopify.Session.setup(api_key="My test key", secret="My test secret")
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
-        self.fake(None, url='https://localhost.myshopify.com/admin/oauth/access_token', method='POST', code=404, body='{"error" : "invalid_request"}', has_user_agent=False)
+        self.fake(None, url='https://localhost.myshopify.com/admin/oauth/access_token',
+                  method='POST', code=404, body='{"error" : "invalid_request"}', has_user_agent=False)
 
         with self.assertRaises(shopify.ValidationException):
-            session.request_token({'code':'any-code', 'timestamp':'1234'})
+            session.request_token({'code': 'any-code', 'timestamp': '1234'})
 
         self.assertFalse(session.valid)
 
@@ -137,45 +144,45 @@ class SessionTest(TestCase):
 
     def test_hmac_calculation(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
-          'shop': 'some-shop.myshopify.com',
-          'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
-          'timestamp': '1337178173',
-          'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
+            'shop': 'some-shop.myshopify.com',
+            'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
+            'timestamp': '1337178173',
+            'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
         }
         self.assertEqual(shopify.Session.calculate_hmac(params), params['hmac'])
 
     def test_hmac_calculation_with_ampersand_and_equal_sign_characters(self):
-        shopify.Session.secret='secret'
-        params = { 'a': '1&b=2', 'c=3&d': '4' }
+        shopify.Session.secret = 'secret'
+        params = {'a': '1&b=2', 'c=3&d': '4'}
         to_sign = "a=1%26b=2&c%3D3%26d=4"
         expected_hmac = hmac.new('secret'.encode(), to_sign.encode(), sha256).hexdigest()
         self.assertEqual(shopify.Session.calculate_hmac(params), expected_hmac)
 
     def test_hmac_validation(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
-          'shop': 'some-shop.myshopify.com',
-          'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
-          'timestamp': '1337178173',
-          'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
+            'shop': 'some-shop.myshopify.com',
+            'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
+            'timestamp': '1337178173',
+            'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
         }
         self.assertTrue(shopify.Session.validate_hmac(params))
 
     def test_parameter_validation_handles_missing_params(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
-          'shop': 'some-shop.myshopify.com',
-          'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
-          'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
+            'shop': 'some-shop.myshopify.com',
+            'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
+            'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
         }
         self.assertFalse(shopify.Session.validate_params(params))
 
     def test_param_validation_of_param_values_with_lists(self):
-        shopify.Session.secret='hush'
+        shopify.Session.secret = 'hush'
         params = {
             'shop': 'some-shop.myshopify.com',
             'ids[]': [
@@ -187,18 +194,19 @@ class SessionTest(TestCase):
         self.assertEqual(True, shopify.Session.validate_hmac(params))
 
     def test_return_token_if_hmac_is_valid(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = {'code': 'any-code', 'timestamp': time.time()}
         hmac = shopify.Session.calculate_hmac(params)
         params['hmac'] = hmac
 
-        self.fake(None, url='https://localhost.myshopify.com/admin/oauth/access_token', method='POST', body='{"access_token" : "token"}', has_user_agent=False)
+        self.fake(None, url='https://localhost.myshopify.com/admin/oauth/access_token',
+                  method='POST', body='{"access_token" : "token"}', has_user_agent=False)
         session = shopify.Session('http://localhost.myshopify.com', 'unstable')
         token = session.request_token(params)
         self.assertEqual("token", token)
 
     def test_raise_error_if_hmac_is_invalid(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = {'code': 'any-code', 'timestamp': time.time()}
         params['hmac'] = 'a94a110d86d2452e92a4a64275b128e9273be3037f2c339eb3e2af4cfb8a3828'
 
@@ -207,7 +215,7 @@ class SessionTest(TestCase):
             session = session.request_token(params)
 
     def test_raise_error_if_hmac_does_not_match_expected(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         params = {'foo': 'hello', 'timestamp': time.time()}
         hmac = shopify.Session.calculate_hmac(params)
         params['hmac'] = hmac
@@ -219,9 +227,9 @@ class SessionTest(TestCase):
             session = session.request_token(params)
 
     def test_raise_error_if_timestamp_is_too_old(self):
-        shopify.Session.secret='secret'
+        shopify.Session.secret = 'secret'
         one_day = 24 * 60 * 60
-        params = {'code': 'any-code', 'timestamp': time.time()-(2*one_day)}
+        params = {'code': 'any-code', 'timestamp': time.time() - (2 * one_day)}
         hmac = shopify.Session.calculate_hmac(params)
         params['hmac'] = hmac
 

--- a/test/shipping_zone_test.py
+++ b/test/shipping_zone_test.py
@@ -1,10 +1,11 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class ShippingZoneTest(TestCase):
     def test_get_shipping_zones(self):
         self.fake("shipping_zones", method='GET', body=self.load_fixture('shipping_zones'))
         shipping_zones = shopify.ShippingZone.find()
-        self.assertEqual(1,len(shipping_zones))
-        self.assertEqual(shipping_zones[0].name,"Some zone")
-        self.assertEqual(3,len(shipping_zones[0].countries))
+        self.assertEqual(1, len(shipping_zones))
+        self.assertEqual(shipping_zones[0].name, "Some zone")
+        self.assertEqual(3, len(shipping_zones[0].countries))

--- a/test/shop_test.py
+++ b/test/shop_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class ShopTest(TestCase):
     def setUp(self):
         super(ShopTest, self).setUp()
@@ -8,7 +9,7 @@ class ShopTest(TestCase):
         self.shop = shopify.Shop.current()
 
     def test_current_should_return_current_shop(self):
-        self.assertTrue(isinstance(self.shop,shopify.Shop))
+        self.assertTrue(isinstance(self.shop, shopify.Shop))
         self.assertEqual("Apple Computers", self.shop.name)
         self.assertEqual("apple.myshopify.com", self.shop.myshopify_domain)
         self.assertEqual(690933842, self.shop.id)
@@ -25,9 +26,11 @@ class ShopTest(TestCase):
             self.assertTrue(isinstance(field, shopify.Metafield))
 
     def test_add_metafield(self):
-        self.fake("metafields", method='POST', code=201, body=self.load_fixture('metafield'), headers={'Content-type': 'application/json'})
+        self.fake("metafields", method='POST', code=201, body=self.load_fixture(
+            'metafield'), headers={'Content-type': 'application/json'})
 
-        field = self.shop.add_metafield( shopify.Metafield({'namespace': "contact", 'key': "email", 'value': "123@example.com", 'value_type': "string"}))
+        field = self.shop.add_metafield(shopify.Metafield(
+            {'namespace': "contact", 'key': "email", 'value': "123@example.com", 'value_type': "string"}))
 
         self.assertFalse(field.is_new())
         self.assertEqual("contact", field.namespace)

--- a/test/storefront_access_token_test.py
+++ b/test/storefront_access_token_test.py
@@ -1,15 +1,18 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class StorefrontAccessTokenTest(TestCase):
     def test_create_storefront_access_token(self):
-        self.fake('storefront_access_tokens', method='POST', body=self.load_fixture('storefront_access_token'), headers={ 'Content-type': 'application/json' })
+        self.fake('storefront_access_tokens', method='POST', body=self.load_fixture(
+            'storefront_access_token'), headers={'Content-type': 'application/json'})
         storefront_access_token = shopify.StorefrontAccessToken.create({'title': 'Test'})
         self.assertEqual(1, storefront_access_token.id)
         self.assertEqual("Test", storefront_access_token.title)
 
     def test_get_and_delete_storefront_access_token(self):
-        self.fake('storefront_access_tokens/1', method='GET', code=200, body=self.load_fixture('storefront_access_token'))
+        self.fake('storefront_access_tokens/1', method='GET', code=200,
+                  body=self.load_fixture('storefront_access_token'))
         storefront_access_token = shopify.StorefrontAccessToken.find(1)
 
         self.fake('storefront_access_tokens/1', method='DELETE', code=200, body='destroyed')
@@ -17,7 +20,8 @@ class StorefrontAccessTokenTest(TestCase):
         self.assertEqual('DELETE', self.http.request.get_method())
 
     def test_get_storefront_access_tokens(self):
-        self.fake('storefront_access_tokens', method='GET', code=200, body=self.load_fixture('storefront_access_tokens'))
+        self.fake('storefront_access_tokens', method='GET', code=200,
+                  body=self.load_fixture('storefront_access_tokens'))
         tokens = shopify.StorefrontAccessToken.find()
 
         self.assertEqual(2, len(tokens))

--- a/test/tender_transaction_test.py
+++ b/test/tender_transaction_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class TenderTransactionTest(TestCase):
     def setUp(self):
         super(TenderTransactionTest, self).setUp()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -5,11 +5,12 @@ from pyactiveresource.activeresource import ActiveResource
 from pyactiveresource.testing import http_fake
 import shopify
 
+
 class TestCase(unittest.TestCase):
 
     def setUp(self):
         ActiveResource.site = None
-        ActiveResource.headers=None
+        ActiveResource.headers = None
 
         shopify.ShopifyResource.clear_session()
         shopify.ShopifyResource.site = "https://this-is-my-test-show.myshopify.com/admin/api/unstable"
@@ -30,13 +31,13 @@ class TestCase(unittest.TestCase):
                   )
 
     def load_fixture(self, name, format='json'):
-        with open(os.path.dirname(__file__)+'/fixtures/%s.%s' % (name, format), 'rb') as f:
+        with open(os.path.dirname(__file__) + '/fixtures/%s.%s' % (name, format), 'rb') as f:
             return f.read()
 
     def fake(self, endpoint, **kwargs):
         body = kwargs.pop('body', None) or self.load_fixture(endpoint)
-        format = kwargs.pop('format','json')
-        method = kwargs.pop('method','GET')
+        format = kwargs.pop('format', 'json')
+        method = kwargs.pop('method', 'GET')
         prefix = kwargs.pop('prefix', '/admin/api/unstable')
 
         if ('extension' in kwargs and not kwargs['extension']):
@@ -55,7 +56,7 @@ class TestCase(unittest.TestCase):
         try:
             headers.update(kwargs['headers'])
         except KeyError:
-           pass
+            pass
 
         code = kwargs.pop('code', 200)
 

--- a/test/transaction_test.py
+++ b/test/transaction_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class TransactionTest(TestCase):
     def setUp(self):
         super(TransactionTest, self).setUp()

--- a/test/usage_charge_test.py
+++ b/test/usage_charge_test.py
@@ -1,16 +1,20 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class UsageChargeTest(TestCase):
     def test_create_usage_charge(self):
-        self.fake("recurring_application_charges/654381177/usage_charges", method='POST', body=self.load_fixture('usage_charge'), headers={'Content-type': 'application/json'})
+        self.fake("recurring_application_charges/654381177/usage_charges", method='POST',
+                  body=self.load_fixture('usage_charge'), headers={'Content-type': 'application/json'})
 
-        charge = shopify.UsageCharge({'price': 9.0, 'description': '1000 emails', 'recurring_application_charge_id': 654381177})
+        charge = shopify.UsageCharge({'price': 9.0, 'description': '1000 emails',
+                                     'recurring_application_charge_id': 654381177})
         charge.save()
         self.assertEqual('1000 emails', charge.description)
 
     def test_get_usage_charge(self):
-        self.fake("recurring_application_charges/654381177/usage_charges/359376002", method='GET', body=self.load_fixture('usage_charge'))
+        self.fake("recurring_application_charges/654381177/usage_charges/359376002",
+                  method='GET', body=self.load_fixture('usage_charge'))
 
-        charge = shopify.UsageCharge.find(359376002, recurring_application_charge_id= 654381177)
+        charge = shopify.UsageCharge.find(359376002, recurring_application_charge_id=654381177)
         self.assertEqual('1000 emails', charge.description)

--- a/test/user_test.py
+++ b/test/user_test.py
@@ -1,6 +1,7 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class UserTest(TestCase):
 
     def test_get_all_users(self):

--- a/test/variant_test.py
+++ b/test/variant_test.py
@@ -1,30 +1,34 @@
 import shopify
 from test.test_helper import TestCase
 
+
 class VariantTest(TestCase):
 
     def test_get_variants(self):
         self.fake("products/632910392/variants", method='GET', body=self.load_fixture('variants'))
-        v = shopify.Variant.find(product_id = 632910392)
+        v = shopify.Variant.find(product_id=632910392)
 
     def test_get_variant_namespaced(self):
         self.fake("products/632910392/variants/808950810", method='GET', body=self.load_fixture('variant'))
-        v = shopify.Variant.find(808950810, product_id = 632910392)
+        v = shopify.Variant.find(808950810, product_id=632910392)
 
     def test_update_variant_namespace(self):
         self.fake("products/632910392/variants/808950810", method='GET', body=self.load_fixture('variant'))
-        v = shopify.Variant.find(808950810, product_id = 632910392)
+        v = shopify.Variant.find(808950810, product_id=632910392)
 
-        self.fake("products/632910392/variants/808950810", method='PUT', body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
+        self.fake("products/632910392/variants/808950810", method='PUT',
+                  body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
         v.save()
 
     def test_create_variant(self):
-        self.fake("products/632910392/variants", method='POST', body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
-        v = shopify.Variant({'product_id':632910392})
+        self.fake("products/632910392/variants", method='POST',
+                  body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
+        v = shopify.Variant({'product_id': 632910392})
         v.save()
 
     def test_create_variant_then_add_parent_id(self):
-        self.fake("products/632910392/variants", method='POST', body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
+        self.fake("products/632910392/variants", method='POST',
+                  body=self.load_fixture('variant'), headers={'Content-type': 'application/json'})
         v = shopify.Variant()
         v.product_id = 632910392
         v.save()


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

- autopep8 automatically formats Python code to conform to the PEP 8 style guide

### WHAT is this pull request doing?
- add autopep8, which is used in [shopify python standards](https://github.com/Shopify/shopify_python)
  - added max line length of 120
- the changes are non-invasive and are mostly whitespace changes

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
