### PR TITLE
Run black to format all quotes

### DIFF
--- a/bin/shopify_api.py
+++ b/bin/shopify_api.py
@@ -8,6 +8,6 @@ import os.path
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
-with open(os.path.join(project_root, 'scripts', 'shopify_api.py')) as f:
-    code = compile(f.read(), f.name, 'exec')
+with open(os.path.join(project_root, "scripts", "shopify_api.py")) as f:
+    code = compile(f.read(), f.name, "exec")
     exec(code)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,3 @@ max_line_length = 120
 
 [tool.black]
 line-length = 120
-skip-string-normalization = true

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -16,7 +16,7 @@ from six.moves import input, map
 def start_interpreter(**variables):
     # add the current working directory to the sys paths
     sys.path.append(os.getcwd())
-    console = type('shopify ' + shopify.version.VERSION, (code.InteractiveConsole, object), {})
+    console = type("shopify " + shopify.version.VERSION, (code.InteractiveConsole, object), {})
     import readline
 
     console(variables).interact()
@@ -54,7 +54,7 @@ class TasksMeta(type):
         return cls
 
     def run_task(cls, task=None, *args):
-        if task in [None, '-h', '--help']:
+        if task in [None, "-h", "--help"]:
             cls.help()
             return
 
@@ -120,22 +120,22 @@ class Tasks(object):
         if os.path.exists(filename):
             raise ConfigFileError("There is already a config file at " + filename)
         else:
-            config = dict(protocol='https')
+            config = dict(protocol="https")
             domain = input("Domain? (leave blank for %s.myshopify.com) " % (connection))
             if not domain.strip():
                 domain = "%s.myshopify.com" % (connection)
-            config['domain'] = domain
+            config["domain"] = domain
             print("")
             print("open https://%s/admin/apps/private in your browser to generate API credentials" % (domain))
-            config['api_key'] = input("API key? ")
-            config['password'] = input("Password? ")
-            config['api_version'] = input("API version? (leave blank for %s) " % (cls._default_api_version))
-            if not config['api_version'].strip():
-                config['api_version'] = cls._default_api_version
+            config["api_key"] = input("API key? ")
+            config["password"] = input("Password? ")
+            config["api_version"] = input("API version? (leave blank for %s) " % (cls._default_api_version))
+            if not config["api_version"].strip():
+                config["api_version"] = cls._default_api_version
 
             if not os.path.isdir(cls._shop_config_dir):
                 os.makedirs(cls._shop_config_dir)
-            with open(filename, 'w') as f:
+            with open(filename, "w") as f:
                 f.write(yaml.dump(config, default_flow_style=False, explicit_start="---"))
         if len(list(cls._available_connections())) == 1:
             cls.default(connection)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup
 
-NAME = 'ShopifyAPI'
-exec(open('shopify/version.py').read())
-DESCRIPTION = 'Shopify API for Python'
+NAME = "ShopifyAPI"
+exec(open("shopify/version.py").read())
+DESCRIPTION = "Shopify API for Python"
 LONG_DESCRIPTION = """\
 The ShopifyAPI library allows python developers to programmatically
 access the admin section of stores using an ActiveResource like
@@ -15,38 +15,38 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
-    author='Shopify',
-    author_email='developers@shopify.com',
-    url='https://github.com/Shopify/shopify_python_api',
-    packages=['shopify', 'shopify/resources'],
-    scripts=['scripts/shopify_api.py'],
-    license='MIT License',
+    author="Shopify",
+    author_email="developers@shopify.com",
+    url="https://github.com/Shopify/shopify_python_api",
+    packages=["shopify", "shopify/resources"],
+    scripts=["scripts/shopify_api.py"],
+    license="MIT License",
     install_requires=[
-        'pyactiveresource>=2.2.2',
-        'PyYAML',
-        'six',
+        "pyactiveresource>=2.2.2",
+        "PyYAML",
+        "six",
     ],
-    test_suite='test',
+    test_suite="test",
     tests_require=[
-        'mock>=1.0.1',
+        "mock>=1.0.1",
     ],
-    platforms='Any',
+    platforms="Any",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -30,13 +30,13 @@ class ApiVersion(object):
     def define_known_versions(cls):
         req = request.urlopen("https://app.shopify.com/services/apis.json")
         data = json.loads(req.read().decode("utf-8"))
-        for api in data['apis']:
-            if api['handle'] == 'admin':
-                for release in api['versions']:
-                    if release['handle'] == 'unstable':
+        for api in data["apis"]:
+            if api["handle"] == "admin":
+                for release in api["versions"]:
+                    if release["handle"] == "unstable":
                         cls.define_version(Unstable())
                     else:
-                        cls.define_version(Release(release['handle']))
+                        cls.define_version(Release(release["handle"]))
 
     @classmethod
     def clear_defined_versions(cls):
@@ -60,15 +60,15 @@ class ApiVersion(object):
 
 
 class Release(ApiVersion):
-    FORMAT = re.compile(r'^\d{4}-\d{2}$')
-    API_PREFIX = '/admin/api'
+    FORMAT = re.compile(r"^\d{4}-\d{2}$")
+    API_PREFIX = "/admin/api"
 
     def __init__(self, version_number):
         if not self.FORMAT.match(version_number):
             raise InvalidVersionError
         self._name = version_number
-        self._numeric_version = int(version_number.replace('-', ''))
-        self._path = '%s/%s' % (self.API_PREFIX, version_number)
+        self._numeric_version = int(version_number.replace("-", ""))
+        self._path = "%s/%s" % (self.API_PREFIX, version_number)
 
     @property
     def stable(self):
@@ -77,9 +77,9 @@ class Release(ApiVersion):
 
 class Unstable(ApiVersion):
     def __init__(self):
-        self._name = 'unstable'
+        self._name = "unstable"
         self._numeric_version = 9000000
-        self._path = '/admin/api/unstable'
+        self._path = "/admin/api/unstable"
 
     @property
     def stable(self):

--- a/shopify/base.py
+++ b/shopify/base.py
@@ -38,7 +38,7 @@ class ShopifyResourceMeta(ResourceMeta):
     def connection(cls):
         """HTTP connection for the current thread"""
         local = cls._threadlocal
-        if not getattr(local, 'connection', None):
+        if not getattr(local, "connection", None):
             # Make sure these variables are no longer affected by other threads.
             local.user = cls.user
             local.password = cls.password
@@ -54,7 +54,7 @@ class ShopifyResourceMeta(ResourceMeta):
         return local.connection
 
     def get_user(cls):
-        return getattr(cls._threadlocal, 'user', ShopifyResource._user)
+        return getattr(cls._threadlocal, "user", ShopifyResource._user)
 
     def set_user(cls, value):
         cls._threadlocal.connection = None
@@ -63,7 +63,7 @@ class ShopifyResourceMeta(ResourceMeta):
     user = property(get_user, set_user, None, "The username for HTTP Basic Auth.")
 
     def get_password(cls):
-        return getattr(cls._threadlocal, 'password', ShopifyResource._password)
+        return getattr(cls._threadlocal, "password", ShopifyResource._password)
 
     def set_password(cls, value):
         cls._threadlocal.connection = None
@@ -72,7 +72,7 @@ class ShopifyResourceMeta(ResourceMeta):
     password = property(get_password, set_password, None, "The password for HTTP Basic Auth.")
 
     def get_site(cls):
-        return getattr(cls._threadlocal, 'site', ShopifyResource._site)
+        return getattr(cls._threadlocal, "site", ShopifyResource._site)
 
     def set_site(cls, value):
         cls._threadlocal.connection = None
@@ -82,49 +82,49 @@ class ShopifyResourceMeta(ResourceMeta):
             host = parts.hostname
             if parts.port:
                 host += ":" + str(parts.port)
-            new_site = urllib.parse.urlunparse((parts.scheme, host, parts.path, '', '', ''))
+            new_site = urllib.parse.urlunparse((parts.scheme, host, parts.path, "", "", ""))
             ShopifyResource._site = cls._threadlocal.site = new_site
             if parts.username:
                 cls.user = urllib.parse.unquote(parts.username)
             if parts.password:
                 cls.password = urllib.parse.unquote(parts.password)
 
-    site = property(get_site, set_site, None, 'The base REST site to connect to.')
+    site = property(get_site, set_site, None, "The base REST site to connect to.")
 
     def get_timeout(cls):
-        return getattr(cls._threadlocal, 'timeout', ShopifyResource._timeout)
+        return getattr(cls._threadlocal, "timeout", ShopifyResource._timeout)
 
     def set_timeout(cls, value):
         cls._threadlocal.connection = None
         ShopifyResource._timeout = cls._threadlocal.timeout = value
 
-    timeout = property(get_timeout, set_timeout, None, 'Socket timeout for HTTP requests')
+    timeout = property(get_timeout, set_timeout, None, "Socket timeout for HTTP requests")
 
     def get_headers(cls):
-        if not hasattr(cls._threadlocal, 'headers'):
+        if not hasattr(cls._threadlocal, "headers"):
             cls._threadlocal.headers = ShopifyResource._headers.copy()
         return cls._threadlocal.headers
 
     def set_headers(cls, value):
         cls._threadlocal.headers = value
 
-    headers = property(get_headers, set_headers, None, 'The headers sent with HTTP requests')
+    headers = property(get_headers, set_headers, None, "The headers sent with HTTP requests")
 
     def get_format(cls):
-        return getattr(cls._threadlocal, 'format', ShopifyResource._format)
+        return getattr(cls._threadlocal, "format", ShopifyResource._format)
 
     def set_format(cls, value):
         cls._threadlocal.connection = None
         ShopifyResource._format = cls._threadlocal.format = value
 
-    format = property(get_format, set_format, None, 'Encoding used for request and responses')
+    format = property(get_format, set_format, None, "Encoding used for request and responses")
 
     def get_prefix_source(cls):
         """Return the prefix source, by default derived from site."""
         try:
             return cls.override_prefix()
         except AttributeError:
-            if hasattr(cls, '_prefix_source'):
+            if hasattr(cls, "_prefix_source"):
                 return cls.site + cls._prefix_source
             else:
                 return cls.site
@@ -133,33 +133,33 @@ class ShopifyResourceMeta(ResourceMeta):
         """Set the prefix source, which will be rendered into the prefix."""
         cls._prefix_source = value
 
-    prefix_source = property(get_prefix_source, set_prefix_source, None, 'prefix for lookups for this type of object.')
+    prefix_source = property(get_prefix_source, set_prefix_source, None, "prefix for lookups for this type of object.")
 
     def get_version(cls):
-        if hasattr(cls._threadlocal, 'version') or ShopifyResource._version:
-            return getattr(cls._threadlocal, 'version', ShopifyResource._version)
+        if hasattr(cls._threadlocal, "version") or ShopifyResource._version:
+            return getattr(cls._threadlocal, "version", ShopifyResource._version)
         elif ShopifyResource._site is not None:
-            return ShopifyResource._site.split('/')[-1]
+            return ShopifyResource._site.split("/")[-1]
 
     def set_version(cls, value):
         ShopifyResource._version = cls._threadlocal.version = value
 
-    version = property(get_version, set_version, None, 'Shopify Api Version')
+    version = property(get_version, set_version, None, "Shopify Api Version")
 
     def get_url(cls):
-        return getattr(cls._threadlocal, 'url', ShopifyResource._url)
+        return getattr(cls._threadlocal, "url", ShopifyResource._url)
 
     def set_url(cls, value):
         ShopifyResource._url = cls._threadlocal.url = value
 
-    url = property(get_url, set_url, None, 'Base URL including protocol and shopify domain')
+    url = property(get_url, set_url, None, "Base URL including protocol and shopify domain")
 
 
 @six.add_metaclass(ShopifyResourceMeta)
 class ShopifyResource(ActiveResource, mixins.Countable):
     _format = formats.JSONFormat
     _threadlocal = threading.local()
-    _headers = {'User-Agent': 'ShopifyPythonAPI/%s Python/%s' % (shopify.VERSION, sys.version.split(' ', 1)[0])}
+    _headers = {"User-Agent": "ShopifyPythonAPI/%s Python/%s" % (shopify.VERSION, sys.version.split(" ", 1)[0])}
     _version = None
     _url = None
 
@@ -182,7 +182,7 @@ class ShopifyResource(ActiveResource, mixins.Countable):
         cls.user = None
         cls.password = None
         cls.version = session.api_version.name
-        cls.headers['X-Shopify-Access-Token'] = session.token
+        cls.headers["X-Shopify-Access-Token"] = session.token
 
     @classmethod
     def clear_session(cls):
@@ -191,7 +191,7 @@ class ShopifyResource(ActiveResource, mixins.Countable):
         cls.user = None
         cls.password = None
         cls.version = None
-        cls.headers.pop('X-Shopify-Access-Token', None)
+        cls.headers.pop("X-Shopify-Access-Token", None)
 
     @classmethod
     def find(cls, id_=None, from_=None, **kwargs):

--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -30,11 +30,11 @@ class PaginatedCollection(Collection):
             super(PaginatedCollection, self).__init__(metadata=metadata or {}, *args, **kwargs)
 
         if not ("resource_class" in self.metadata):
-            raise AttributeError("Cursor-based pagination requires a \"resource_class\" attribute in the metadata.")
+            raise AttributeError('Cursor-based pagination requires a "resource_class" attribute in the metadata.')
 
         self.metadata["pagination"] = self.__parse_pagination()
-        self.next_page_url = self.metadata["pagination"].get('next', None)
-        self.previous_page_url = self.metadata["pagination"].get('previous', None)
+        self.next_page_url = self.metadata["pagination"].get("next", None)
+        self.previous_page_url = self.metadata["pagination"].get("previous", None)
 
         self._next = None
         self._previous = None

--- a/shopify/limits.py
+++ b/shopify/limits.py
@@ -11,7 +11,7 @@ class Limits(object):
 
     # num_requests_executed/max_requests
     # Eg: 1/40
-    CREDIT_LIMIT_HEADER_PARAM = 'X-Shopify-Shop-Api-Call-Limit'
+    CREDIT_LIMIT_HEADER_PARAM = "X-Shopify-Shop-Api-Call-Limit"
 
     @classmethod
     def response(cls):
@@ -22,14 +22,14 @@ class Limits(object):
     @classmethod
     def api_credit_limit_param(cls):
         response = cls.response()
-        _safe_header = getattr(response, "headers", '')
+        _safe_header = getattr(response, "headers", "")
 
         if not _safe_header:
             raise Exception("No shopify headers found")
 
         if cls.CREDIT_LIMIT_HEADER_PARAM in response.headers:
             credits = response.headers[cls.CREDIT_LIMIT_HEADER_PARAM]
-            return credits.split('/')
+            return credits.split("/")
         else:
             raise Exception("No valid api call header found")
 

--- a/shopify/resources/api_permission.py
+++ b/shopify/resources/api_permission.py
@@ -4,6 +4,6 @@ from ..base import ShopifyResource
 class ApiPermission(ShopifyResource):
     @classmethod
     def delete(cls):
-        cls.connection.delete(cls.site + '/api_permissions/current.' + cls.format.extension, cls.headers)
+        cls.connection.delete(cls.site + "/api_permissions/current." + cls.format.extension, cls.headers)
 
     destroy = delete

--- a/shopify/resources/article.py
+++ b/shopify/resources/article.py
@@ -19,8 +19,8 @@ class Article(ShopifyResource, mixins.Metafields, mixins.Events):
 
     @classmethod
     def authors(cls, **kwargs):
-        return cls.get('authors', **kwargs)
+        return cls.get("authors", **kwargs)
 
     @classmethod
     def tags(cls, **kwargs):
-        return cls.get('tags', **kwargs)
+        return cls.get("tags", **kwargs)

--- a/shopify/resources/asset.py
+++ b/shopify/resources/asset.py
@@ -19,7 +19,7 @@ class Asset(ShopifyResource):
         if query_options is None:
             prefix_options, query_options = cls._split_options(prefix_options)
         return "%s%s.%s%s" % (
-            cls._prefix(prefix_options) + '/',
+            cls._prefix(prefix_options) + "/",
             cls.plural,
             cls.format.extension,
             cls._query_string(query_options),

--- a/shopify/resources/balance.py
+++ b/shopify/resources/balance.py
@@ -4,4 +4,4 @@ from shopify import mixins
 
 class Balance(ShopifyResource, mixins.Metafields):
     _prefix_source = "/shopify_payments/"
-    _singular = _plural = 'balance'
+    _singular = _plural = "balance"

--- a/shopify/resources/collection_listing.py
+++ b/shopify/resources/collection_listing.py
@@ -5,4 +5,4 @@ class CollectionListing(ShopifyResource):
     _primary_key = "collection_id"
 
     def product_ids(cls, **kwargs):
-        return cls.get('product_ids', **kwargs)
+        return cls.get("product_ids", **kwargs)

--- a/shopify/resources/custom_collection.py
+++ b/shopify/resources/custom_collection.py
@@ -8,7 +8,7 @@ class CustomCollection(ShopifyResource, mixins.Metafields, mixins.Events):
         return shopify.Product.find(collection_id=self.id)
 
     def add_product(self, product):
-        return shopify.Collect.create({'collection_id': self.id, 'product_id': product.id})
+        return shopify.Collect.create({"collection_id": self.id, "product_id": product.id})
 
     def remove_product(self, product):
         collect = shopify.Collect.find_first(collection_id=self.id, product_id=product.id)

--- a/shopify/resources/discount_code_creation.py
+++ b/shopify/resources/discount_code_creation.py
@@ -10,7 +10,7 @@ class DiscountCodeCreation(ShopifyResource):
             from_="%s/price_rules/%s/batch/%s/discount_codes.%s"
             % (
                 ShopifyResource.site,
-                self._prefix_options['price_rule_id'],
+                self._prefix_options["price_rule_id"],
                 self.id,
                 DiscountCodeCreation.format.extension,
             )

--- a/shopify/resources/draft_order.py
+++ b/shopify/resources/draft_order.py
@@ -9,7 +9,7 @@ class DraftOrder(ShopifyResource, mixins.Metafields):
         return DraftOrderInvoice(DraftOrder.format.decode(resource.body))
 
     def complete(self, params={}):
-        if params.get('payment_pending', False):
-            self._load_attributes_from_response(self.put("complete", payment_pending='true'))
+        if params.get("payment_pending", False):
+            self._load_attributes_from_response(self.put("complete", payment_pending="true"))
         else:
             self._load_attributes_from_response(self.put("complete"))

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -25,8 +25,8 @@ class FulfillmentOrders(ShopifyResource):
 
 
 class FulfillmentV2(ShopifyResource):
-    _singular = 'fulfillment'
-    _plural = 'fulfillments'
+    _singular = "fulfillment"
+    _plural = "fulfillments"
 
     def update_tracking(self, tracking_info, notify_customer):
         body = {"fulfillment": {"tracking_info": tracking_info, "notify_customer": notify_customer}}

--- a/shopify/resources/fulfillment_event.py
+++ b/shopify/resources/fulfillment_event.py
@@ -3,30 +3,30 @@ from ..base import ShopifyResource
 
 class FulfillmentEvent(ShopifyResource):
     _prefix_source = "/orders/$order_id/fulfillments/$fulfillment_id/"
-    _singular = 'event'
-    _plural = 'events'
+    _singular = "event"
+    _plural = "events"
 
     @classmethod
     def _prefix(cls, options={}):
         order_id = options.get("order_id")
-        fulfillment_id = options.get('fulfillment_id')
+        fulfillment_id = options.get("fulfillment_id")
         event_id = options.get("event_id")
 
         return "%s/orders/%s/fulfillments/%s" % (cls.site, order_id, fulfillment_id)
 
     def save(self):
-        status = self.attributes['status']
+        status = self.attributes["status"]
         if status not in [
-            'label_printed',
-            'label_purchased',
-            'attempted_delivery',
-            'ready_for_pickup',
-            'picked_up',
-            'confirmed',
-            'in_transit',
-            'out_for_delivery',
-            'delivered',
-            'failure',
+            "label_printed",
+            "label_purchased",
+            "attempted_delivery",
+            "ready_for_pickup",
+            "picked_up",
+            "confirmed",
+            "in_transit",
+            "out_for_delivery",
+            "delivered",
+            "failure",
         ]:
             raise AttributeError("Invalid status")
         return super(ShopifyResource, self).save()

--- a/shopify/resources/gift_card_adjustment.py
+++ b/shopify/resources/gift_card_adjustment.py
@@ -3,5 +3,5 @@ from ..base import ShopifyResource
 
 class GiftCardAdjustment(ShopifyResource):
     _prefix_source = "/admin/gift_cards/$gift_card_id/"
-    _plural = 'adjustments'
-    _singular = 'adjustment'
+    _plural = "adjustments"
+    _singular = "adjustment"

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -17,16 +17,16 @@ class GraphQL:
 
     def execute(self, query, variables=None):
         endpoint = self.endpoint
-        default_headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
         headers = self.merge_headers(default_headers, self.headers)
-        data = {'query': query, 'variables': variables}
+        data = {"query": query, "variables": variables}
 
-        req = urllib.request.Request(self.endpoint, json.dumps(data).encode('utf-8'), headers)
+        req = urllib.request.Request(self.endpoint, json.dumps(data).encode("utf-8"), headers)
 
         try:
             response = urllib.request.urlopen(req)
-            return response.read().decode('utf-8')
+            return response.read().decode("utf-8")
         except urllib.error.HTTPError as e:
             print((e.read()))
-            print('')
+            print("")
             raise e

--- a/shopify/resources/image.py
+++ b/shopify/resources/image.py
@@ -30,12 +30,12 @@ class Image(ShopifyResource):
     def metafields(self):
         if self.is_new():
             return []
-        query_params = {'metafield[owner_id]': self.id, 'metafield[owner_resource]': 'product_image'}
+        query_params = {"metafield[owner_id]": self.id, "metafield[owner_resource]": "product_image"}
         return Metafield.find(
-            from_='%s/metafields.json?%s' % (ShopifyResource.site, urllib.parse.urlencode(query_params))
+            from_="%s/metafields.json?%s" % (ShopifyResource.site, urllib.parse.urlencode(query_params))
         )
 
     def save(self):
-        if 'product_id' not in self._prefix_options:
-            self._prefix_options['product_id'] = self.product_id
+        if "product_id" not in self._prefix_options:
+            self._prefix_options["product_id"] = self.product_id
         return super(ShopifyResource, self).save()

--- a/shopify/resources/inventory_level.py
+++ b/shopify/resources/inventory_level.py
@@ -5,7 +5,7 @@ import json
 
 class InventoryLevel(ShopifyResource):
     def __repr__(self):
-        return '%s(inventory_item_id=%s, location_id=%s)' % (self._singular, self.inventory_item_id, self.location_id)
+        return "%s(inventory_item_id=%s, location_id=%s)" % (self._singular, self.inventory_item_id, self.location_id)
 
     @classmethod
     def _element_path(cls, prefix_options={}, query_options=None):
@@ -13,7 +13,7 @@ class InventoryLevel(ShopifyResource):
             prefix_options, query_options = cls._split_options(prefix_options)
 
         return "%s%s.%s%s" % (
-            cls._prefix(prefix_options) + '/',
+            cls._prefix(prefix_options) + "/",
             cls.plural,
             cls.format.extension,
             cls._query_string(query_options),
@@ -22,32 +22,32 @@ class InventoryLevel(ShopifyResource):
     @classmethod
     def adjust(cls, location_id, inventory_item_id, available_adjustment):
         body = {
-            'inventory_item_id': inventory_item_id,
-            'location_id': location_id,
-            'available_adjustment': available_adjustment,
+            "inventory_item_id": inventory_item_id,
+            "location_id": location_id,
+            "available_adjustment": available_adjustment,
         }
-        resource = cls.post('adjust', body=json.dumps(body).encode())
+        resource = cls.post("adjust", body=json.dumps(body).encode())
         return InventoryLevel(InventoryLevel.format.decode(resource.body))
 
     @classmethod
     def connect(cls, location_id, inventory_item_id, relocate_if_necessary=False, **kwargs):
         body = {
-            'inventory_item_id': inventory_item_id,
-            'location_id': location_id,
-            'relocate_if_necessary': relocate_if_necessary,
+            "inventory_item_id": inventory_item_id,
+            "location_id": location_id,
+            "relocate_if_necessary": relocate_if_necessary,
         }
-        resource = cls.post('connect', body=json.dumps(body).encode())
+        resource = cls.post("connect", body=json.dumps(body).encode())
         return InventoryLevel(InventoryLevel.format.decode(resource.body))
 
     @classmethod
     def set(cls, location_id, inventory_item_id, available, disconnect_if_necessary=False, **kwargs):
         body = {
-            'inventory_item_id': inventory_item_id,
-            'location_id': location_id,
-            'available': available,
-            'disconnect_if_necessary': disconnect_if_necessary,
+            "inventory_item_id": inventory_item_id,
+            "location_id": location_id,
+            "available": available,
+            "disconnect_if_necessary": disconnect_if_necessary,
         }
-        resource = cls.post('set', body=json.dumps(body).encode())
+        resource = cls.post("set", body=json.dumps(body).encode())
         return InventoryLevel(InventoryLevel.format.decode(resource.body))
 
     def is_new(self):

--- a/shopify/resources/marketing_event.py
+++ b/shopify/resources/marketing_event.py
@@ -4,5 +4,5 @@ from ..base import ShopifyResource
 
 class MarketingEvent(ShopifyResource):
     def add_engagements(self, engagements):
-        engagements_json = json.dumps({'engagements': engagements})
-        return self.post('engagements', engagements_json.encode())
+        engagements_json = json.dumps({"engagements": engagements})
+        return self.post("engagements", engagements_json.encode())

--- a/shopify/resources/price_rule.py
+++ b/shopify/resources/price_rule.py
@@ -13,7 +13,7 @@ class PriceRule(ShopifyResource):
         return DiscountCode.find(price_rule_id=self.id)
 
     def create_batch(self, codes=[]):
-        codes_json = json.dumps({'discount_codes': codes})
+        codes_json = json.dumps({"discount_codes": codes})
 
         response = self.post("batch", codes_json.encode())
         return DiscountCodeCreation(PriceRule.format.decode(response.body))

--- a/shopify/resources/product.py
+++ b/shopify/resources/product.py
@@ -27,17 +27,17 @@ class Product(ShopifyResource, mixins.Metafields, mixins.Events):
         return collection.remove_product(self)
 
     def add_variant(self, variant):
-        variant.attributes['product_id'] = self.id
+        variant.attributes["product_id"] = self.id
         return variant.save()
 
     def save(self):
-        start_api_version = '201910'
+        start_api_version = "201910"
         api_version = ShopifyResource.version
-        if api_version and (api_version.strip('-') >= start_api_version) and api_version != 'unstable':
-            if 'variants' in self.attributes:
+        if api_version and (api_version.strip("-") >= start_api_version) and api_version != "unstable":
+            if "variants" in self.attributes:
                 for variant in self.variants:
-                    if 'inventory_quantity' in variant.attributes:
-                        del variant.attributes['inventory_quantity']
-                    if 'old_inventory_quantity' in variant.attributes:
-                        del variant.attributes['old_inventory_quantity']
+                    if "inventory_quantity" in variant.attributes:
+                        del variant.attributes["inventory_quantity"]
+                    if "old_inventory_quantity" in variant.attributes:
+                        del variant.attributes["old_inventory_quantity"]
         return super(ShopifyResource, self).save()

--- a/shopify/resources/product_listing.py
+++ b/shopify/resources/product_listing.py
@@ -6,4 +6,4 @@ class ProductListing(ShopifyResource):
 
     @classmethod
     def product_ids(cls, **kwargs):
-        return cls.get('product_ids', **kwargs)
+        return cls.get("product_ids", **kwargs)

--- a/shopify/resources/refund.py
+++ b/shopify/resources/refund.py
@@ -22,8 +22,8 @@ class Refund(ShopifyResource):
         """
         data = {}
         if shipping:
-            data['shipping'] = shipping
-        data['refund_line_items'] = refund_line_items or []
-        body = {'refund': data}
+            data["shipping"] = shipping
+        data["refund_line_items"] = refund_line_items or []
+        body = {"refund": data}
         resource = cls.post("calculate", order_id=order_id, body=json.dumps(body).encode())
-        return cls(cls.format.decode(resource.body), prefix_options={'order_id': order_id})
+        return cls(cls.format.decode(resource.body), prefix_options={"order_id": order_id})

--- a/shopify/resources/user.py
+++ b/shopify/resources/user.py
@@ -4,4 +4,4 @@ from ..base import ShopifyResource
 class User(ShopifyResource):
     @classmethod
     def current(cls):
-        return User(cls.get('current'))
+        return User(cls.get("current"))

--- a/shopify/resources/variant.py
+++ b/shopify/resources/variant.py
@@ -14,15 +14,15 @@ class Variant(ShopifyResource, mixins.Metafields):
             return cls.site
 
     def save(self):
-        if 'product_id' not in self._prefix_options:
-            self._prefix_options['product_id'] = self.product_id
+        if "product_id" not in self._prefix_options:
+            self._prefix_options["product_id"] = self.product_id
 
-        start_api_version = '201910'
+        start_api_version = "201910"
         api_version = ShopifyResource.version
-        if api_version and (api_version.strip('-') >= start_api_version) and api_version != 'unstable':
-            if 'inventory_quantity' in self.attributes:
-                del self.attributes['inventory_quantity']
-            if 'old_inventory_quantity' in self.attributes:
-                del self.attributes['old_inventory_quantity']
+        if api_version and (api_version.strip("-") >= start_api_version) and api_version != "unstable":
+            if "inventory_quantity" in self.attributes:
+                del self.attributes["inventory_quantity"]
+            if "old_inventory_quantity" in self.attributes:
+                del self.attributes["old_inventory_quantity"]
 
         return super(ShopifyResource, self).save()

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -21,8 +21,8 @@ class ValidationException(Exception):
 class Session(object):
     api_key = None
     secret = None
-    protocol = 'https'
-    myshopify_domain = 'myshopify.com'
+    protocol = "https"
+    myshopify_domain = "myshopify.com"
     port = None
 
     @classmethod
@@ -36,7 +36,7 @@ class Session(object):
         import shopify
 
         original_domain = shopify.ShopifyResource.url
-        original_token = shopify.ShopifyResource.get_headers().get('X-Shopify-Access-Token')
+        original_token = shopify.ShopifyResource.get_headers().get("X-Shopify-Access-Token")
         original_version = shopify.ShopifyResource.get_version() or version
         original_session = shopify.Session(original_domain, original_version, original_token)
 
@@ -54,7 +54,7 @@ class Session(object):
     def create_permission_url(self, scope, redirect_uri, state=None):
         query_params = dict(client_id=self.api_key, scope=",".join(scope), redirect_uri=redirect_uri)
         if state:
-            query_params['state'] = state
+            query_params["state"] = state
         return "https://%s/admin/oauth/authorize?%s" % (self.url, urllib.parse.urlencode(query_params))
 
     def request_token(self, params):
@@ -62,17 +62,17 @@ class Session(object):
             return self.token
 
         if not self.validate_params(params):
-            raise ValidationException('Invalid HMAC: Possibly malicious login')
+            raise ValidationException("Invalid HMAC: Possibly malicious login")
 
-        code = params['code']
+        code = params["code"]
 
         url = "https://%s/admin/oauth/access_token?" % self.url
         query_params = dict(client_id=self.api_key, client_secret=self.secret, code=code)
-        request = urllib.request.Request(url, urllib.parse.urlencode(query_params).encode('utf-8'))
+        request = urllib.request.Request(url, urllib.parse.urlencode(query_params).encode("utf-8"))
         response = urllib.request.urlopen(request)
 
         if response.code == 200:
-            self.token = json.loads(response.read().decode('utf-8'))['access_token']
+            self.token = json.loads(response.read().decode("utf-8"))["access_token"]
             return self.token
         else:
             raise Exception(response.msg)
@@ -112,18 +112,18 @@ class Session(object):
         # Avoid replay attacks by making sure the request
         # isn't more than a day old.
         one_day = 24 * 60 * 60
-        if int(params.get('timestamp', 0)) < time.time() - one_day:
+        if int(params.get("timestamp", 0)) < time.time() - one_day:
             return False
 
         return cls.validate_hmac(params)
 
     @classmethod
     def validate_hmac(cls, params):
-        if 'hmac' not in params:
+        if "hmac" not in params:
             return False
 
-        hmac_calculated = cls.calculate_hmac(params).encode('utf-8')
-        hmac_to_verify = params['hmac'].encode('utf-8')
+        hmac_calculated = cls.calculate_hmac(params).encode("utf-8")
+        hmac_to_verify = params["hmac"].encode("utf-8")
 
         # Try to use compare_digest() to reduce vulnerability to timing attacks.
         # If it's not available, just fall back to regular string comparison.
@@ -150,17 +150,17 @@ class Session(object):
 
         def encoded_pairs(params):
             for k, v in six.iteritems(params):
-                if k == 'hmac':
+                if k == "hmac":
                     continue
 
-                if k.endswith('[]'):
+                if k.endswith("[]"):
                     # foo[]=1&foo[]=2 has to be transformed as foo=["1", "2"] note the whitespace after comma
-                    k = k.rstrip('[]')
+                    k = k.rstrip("[]")
                     v = json.dumps(list(map(str, v)))
 
                 # escape delimiters to avoid tampering
                 k = str(k).replace("%", "%25").replace("=", "%3D")
                 v = str(v).replace("%", "%25")
-                yield '{0}={1}'.format(k, v).replace("&", "%26")
+                yield "{0}={1}".format(k, v).replace("&", "%26")
 
         return "&".join(sorted(encoded_pairs(params)))

--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = '8.2.0'
+VERSION = "8.2.0"

--- a/shopify/yamlobjects.py
+++ b/shopify/yamlobjects.py
@@ -8,7 +8,7 @@ try:
     import yaml
 
     class YAMLHashWithIndifferentAccess(yaml.YAMLObject):
-        yaml_tag = '!map:ActiveSupport::HashWithIndifferentAccess'
+        yaml_tag = "!map:ActiveSupport::HashWithIndifferentAccess"
         yaml_loader = yaml.SafeLoader
 
         @classmethod

--- a/test/access_scope_test.py
+++ b/test/access_scope_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class AccessScopeTest(TestCase):
     def test_find_should_return_all_access_scopes(self):
-        self.fake('oauth/access_scopes', body=self.load_fixture('access_scopes'), prefix='/admin')
+        self.fake("oauth/access_scopes", body=self.load_fixture("access_scopes"), prefix="/admin")
         scopes = shopify.AccessScope.find()
         self.assertEqual(3, len(scopes))
-        self.assertEqual('read_products', scopes[0].handle)
+        self.assertEqual("read_products", scopes[0].handle)

--- a/test/api_permission_test.py
+++ b/test/api_permission_test.py
@@ -4,6 +4,6 @@ from test.test_helper import TestCase
 
 class ApiPermissionTest(TestCase):
     def test_delete_api_permission(self):
-        self.fake('api_permissions/current', method='DELETE', code=200, body='{}')
+        self.fake("api_permissions/current", method="DELETE", code=200, body="{}")
 
         shopify.ApiPermission.delete()

--- a/test/api_version_test.py
+++ b/test/api_version_test.py
@@ -13,35 +13,35 @@ class ApiVersionTest(TestCase):
 
     def test_unstable_api_path_returns_correct_url(self):
         self.assertEqual(
-            'https://fakeshop.myshopify.com/admin/api/unstable',
-            shopify.Unstable().api_path('https://fakeshop.myshopify.com'),
+            "https://fakeshop.myshopify.com/admin/api/unstable",
+            shopify.Unstable().api_path("https://fakeshop.myshopify.com"),
         )
 
     def test_coerce_to_version_returns_known_versions(self):
         v1 = shopify.Unstable()
-        v2 = shopify.ApiVersion.define_version(shopify.Release('2019-01'))
+        v2 = shopify.ApiVersion.define_version(shopify.Release("2019-01"))
 
         self.assertNotEqual(v1, None)
-        self.assertEqual(v1, shopify.ApiVersion.coerce_to_version('unstable'))
-        self.assertEqual(v2, shopify.ApiVersion.coerce_to_version('2019-01'))
+        self.assertEqual(v1, shopify.ApiVersion.coerce_to_version("unstable"))
+        self.assertEqual(v2, shopify.ApiVersion.coerce_to_version("2019-01"))
 
     def test_coerce_to_version_raises_with_string_that_does_not_match_known_version(self):
         with self.assertRaises(shopify.VersionNotFoundError):
-            shopify.ApiVersion.coerce_to_version('crazy-name')
+            shopify.ApiVersion.coerce_to_version("crazy-name")
 
 
 class ReleaseTest(TestCase):
     def test_raises_if_format_invalid(self):
         with self.assertRaises(shopify.InvalidVersionError):
-            shopify.Release('crazy-name')
+            shopify.Release("crazy-name")
 
     def test_release_api_path_returns_correct_url(self):
         self.assertEqual(
-            'https://fakeshop.myshopify.com/admin/api/2019-04',
-            shopify.Release('2019-04').api_path('https://fakeshop.myshopify.com'),
+            "https://fakeshop.myshopify.com/admin/api/2019-04",
+            shopify.Release("2019-04").api_path("https://fakeshop.myshopify.com"),
         )
 
     def test_two_release_versions_with_same_number_are_equal(self):
-        version1 = shopify.Release('2019-01')
-        version2 = shopify.Release('2019-01')
+        version1 = shopify.Release("2019-01")
+        version2 = shopify.Release("2019-01")
         self.assertEqual(version1, version2)

--- a/test/application_credit_test.py
+++ b/test/application_credit_test.py
@@ -5,27 +5,27 @@ from test.test_helper import TestCase
 
 class ApplicationCreditTest(TestCase):
     def test_get_application_credit(self):
-        self.fake('application_credits/445365009', method='GET', body=self.load_fixture('application_credit'), code=200)
+        self.fake("application_credits/445365009", method="GET", body=self.load_fixture("application_credit"), code=200)
         application_credit = shopify.ApplicationCredit.find(445365009)
-        self.assertEqual('5.00', application_credit.amount)
+        self.assertEqual("5.00", application_credit.amount)
 
     def test_get_all_application_credits(self):
-        self.fake('application_credits', method='GET', body=self.load_fixture('application_credits'), code=200)
+        self.fake("application_credits", method="GET", body=self.load_fixture("application_credits"), code=200)
         application_credits = shopify.ApplicationCredit.find()
         self.assertEqual(1, len(application_credits))
         self.assertEqual(445365009, application_credits[0].id)
 
     def test_create_application_credit(self):
         self.fake(
-            'application_credits',
-            method='POST',
-            body=self.load_fixture('application_credit'),
-            headers={'Content-type': 'application/json'},
+            "application_credits",
+            method="POST",
+            body=self.load_fixture("application_credit"),
+            headers={"Content-type": "application/json"},
             code=201,
         )
 
         application_credit = shopify.ApplicationCredit.create(
-            {'description': 'application credit for refund', 'amount': 5.0}
+            {"description": "application credit for refund", "amount": 5.0}
         )
 
         expected_body = {"application_credit": {"description": "application credit for refund", "amount": 5.0}}

--- a/test/article_test.py
+++ b/test/article_test.py
@@ -6,70 +6,70 @@ class ArticleTest(TestCase):
     def test_create_article(self):
         self.fake(
             "blogs/1008414260/articles",
-            method='POST',
-            body=self.load_fixture('article'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("article"),
+            headers={"Content-type": "application/json"},
         )
-        article = shopify.Article({'blog_id': 1008414260})
+        article = shopify.Article({"blog_id": 1008414260})
         article.save()
         self.assertEqual("First Post", article.title)
 
     def test_get_article(self):
-        self.fake('articles/6242736', method='GET', body=self.load_fixture('article'))
+        self.fake("articles/6242736", method="GET", body=self.load_fixture("article"))
         article = shopify.Article.find(6242736)
         self.assertEqual("First Post", article.title)
 
     def test_update_article(self):
-        self.fake('articles/6242736', method='GET', body=self.load_fixture('article'))
+        self.fake("articles/6242736", method="GET", body=self.load_fixture("article"))
         article = shopify.Article.find(6242736)
 
         self.fake(
-            'articles/6242736',
-            method='PUT',
-            body=self.load_fixture('article'),
-            headers={'Content-type': 'application/json'},
+            "articles/6242736",
+            method="PUT",
+            body=self.load_fixture("article"),
+            headers={"Content-type": "application/json"},
         )
         article.save()
 
     def test_get_articles(self):
-        self.fake("articles", method='GET', body=self.load_fixture('articles'))
+        self.fake("articles", method="GET", body=self.load_fixture("articles"))
         articles = shopify.Article.find()
         self.assertEqual(3, len(articles))
 
     def test_get_articles_namespaced(self):
-        self.fake("blogs/1008414260/articles", method='GET', body=self.load_fixture('articles'))
+        self.fake("blogs/1008414260/articles", method="GET", body=self.load_fixture("articles"))
         articles = shopify.Article.find(blog_id=1008414260)
         self.assertEqual(3, len(articles))
 
     def test_get_article_namespaced(self):
-        self.fake("blogs/1008414260/articles/6242736", method='GET', body=self.load_fixture('article'))
+        self.fake("blogs/1008414260/articles/6242736", method="GET", body=self.load_fixture("article"))
         article = shopify.Article.find(6242736, blog_id=1008414260)
         self.assertEqual("First Post", article.title)
 
     def test_get_authors(self):
-        self.fake("articles/authors", method='GET', body=self.load_fixture('authors'))
+        self.fake("articles/authors", method="GET", body=self.load_fixture("authors"))
         authors = shopify.Article.authors()
         self.assertEqual("Shopify", authors[0])
         self.assertEqual("development shop", authors[-1])
 
     def test_get_authors_for_blog_id(self):
-        self.fake("blogs/1008414260/articles/authors", method='GET', body=self.load_fixture('authors'))
+        self.fake("blogs/1008414260/articles/authors", method="GET", body=self.load_fixture("authors"))
         authors = shopify.Article.authors(blog_id=1008414260)
         self.assertEqual(3, len(authors))
 
     def test_get_tags(self):
-        self.fake("articles/tags", method='GET', body=self.load_fixture('tags'))
+        self.fake("articles/tags", method="GET", body=self.load_fixture("tags"))
         tags = shopify.Article.tags()
         self.assertEqual("consequuntur", tags[0])
         self.assertEqual("repellendus", tags[-1])
 
     def test_get_tags_for_blog_id(self):
-        self.fake("blogs/1008414260/articles/tags", method='GET', body=self.load_fixture('tags'))
+        self.fake("blogs/1008414260/articles/tags", method="GET", body=self.load_fixture("tags"))
         tags = shopify.Article.tags(blog_id=1008414260)
         self.assertEqual("consequuntur", tags[0])
         self.assertEqual("repellendus", tags[-1])
 
     def test_get_popular_tags(self):
-        self.fake("articles/tags.json?limit=1&popular=1", extension=False, method='GET', body=self.load_fixture('tags'))
+        self.fake("articles/tags.json?limit=1&popular=1", extension=False, method="GET", body=self.load_fixture("tags"))
         tags = shopify.Article.tags(popular=1, limit=1)
         self.assertEqual(3, len(tags))

--- a/test/asset_test.py
+++ b/test/asset_test.py
@@ -6,57 +6,57 @@ from test.test_helper import TestCase
 
 class AssetTest(TestCase):
     def test_get_assets(self):
-        self.fake("assets", method='GET', body=self.load_fixture('assets'))
+        self.fake("assets", method="GET", body=self.load_fixture("assets"))
         v = shopify.Asset.find()
 
     def test_get_asset(self):
         self.fake(
             "assets.json?asset%5Bkey%5D=templates%2Findex.liquid",
             extension=False,
-            method='GET',
-            body=self.load_fixture('asset'),
+            method="GET",
+            body=self.load_fixture("asset"),
         )
-        v = shopify.Asset.find('templates/index.liquid')
+        v = shopify.Asset.find("templates/index.liquid")
 
     def test_update_asset(self):
         self.fake(
             "assets.json?asset%5Bkey%5D=templates%2Findex.liquid",
             extension=False,
-            method='GET',
-            body=self.load_fixture('asset'),
+            method="GET",
+            body=self.load_fixture("asset"),
         )
-        v = shopify.Asset.find('templates/index.liquid')
+        v = shopify.Asset.find("templates/index.liquid")
 
-        self.fake("assets", method='PUT', body=self.load_fixture('asset'), headers={'Content-type': 'application/json'})
+        self.fake("assets", method="PUT", body=self.load_fixture("asset"), headers={"Content-type": "application/json"})
         v.save()
 
     def test_get_assets_namespaced(self):
-        self.fake("themes/1/assets", method='GET', body=self.load_fixture('assets'))
+        self.fake("themes/1/assets", method="GET", body=self.load_fixture("assets"))
         v = shopify.Asset.find(theme_id=1)
 
     def test_get_asset_namespaced(self):
         self.fake(
             "themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1",
             extension=False,
-            method='GET',
-            body=self.load_fixture('asset'),
+            method="GET",
+            body=self.load_fixture("asset"),
         )
-        v = shopify.Asset.find('templates/index.liquid', theme_id=1)
+        v = shopify.Asset.find("templates/index.liquid", theme_id=1)
 
     def test_update_asset_namespaced(self):
         self.fake(
             "themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1",
             extension=False,
-            method='GET',
-            body=self.load_fixture('asset'),
+            method="GET",
+            body=self.load_fixture("asset"),
         )
-        v = shopify.Asset.find('templates/index.liquid', theme_id=1)
+        v = shopify.Asset.find("templates/index.liquid", theme_id=1)
 
         self.fake(
             "themes/1/assets",
-            method='PUT',
-            body=self.load_fixture('asset'),
-            headers={'Content-type': 'application/json'},
+            method="PUT",
+            body=self.load_fixture("asset"),
+            headers={"Content-type": "application/json"},
         )
         v.save()
 
@@ -64,27 +64,27 @@ class AssetTest(TestCase):
         self.fake(
             "themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid&theme_id=1",
             extension=False,
-            method='GET',
-            body=self.load_fixture('asset'),
+            method="GET",
+            body=self.load_fixture("asset"),
         )
-        v = shopify.Asset.find('templates/index.liquid', theme_id=1)
+        v = shopify.Asset.find("templates/index.liquid", theme_id=1)
 
         self.fake(
-            "themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid", extension=False, method='DELETE', body="{}"
+            "themes/1/assets.json?asset%5Bkey%5D=templates%2Findex.liquid", extension=False, method="DELETE", body="{}"
         )
         v.destroy()
 
     def test_attach(self):
         self.fake(
             "themes/1/assets",
-            method='PUT',
-            body=self.load_fixture('asset'),
-            headers={'Content-type': 'application/json'},
+            method="PUT",
+            body=self.load_fixture("asset"),
+            headers={"Content-type": "application/json"},
         )
-        attachment = b'dGVzdCBiaW5hcnkgZGF0YTogAAE='
-        key = 'assets/test.jpeg'
+        attachment = b"dGVzdCBiaW5hcnkgZGF0YTogAAE="
+        key = "assets/test.jpeg"
         theme_id = 1
-        asset = shopify.Asset({'key': key, 'theme_id': theme_id})
+        asset = shopify.Asset({"key": key, "theme_id": theme_id})
         asset.attach(attachment)
         asset.save()
-        self.assertEqual(base64.b64encode(attachment).decode(), asset.attributes['attachment'])
+        self.assertEqual(base64.b64encode(attachment).decode(), asset.attributes["attachment"])

--- a/test/balance_test.py
+++ b/test/balance_test.py
@@ -3,9 +3,9 @@ from test.test_helper import TestCase
 
 
 class BalanceTest(TestCase):
-    prefix = '/admin/api/unstable/shopify_payments'
+    prefix = "/admin/api/unstable/shopify_payments"
 
     def test_get_balance(self):
-        self.fake('balance', method='GET', prefix=self.prefix, body=self.load_fixture('balance'))
+        self.fake("balance", method="GET", prefix=self.prefix, body=self.load_fixture("balance"))
         balance = shopify.Balance.find()
         self.assertGreater(len(balance), 0)

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -9,9 +9,9 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(self):
         shopify.ApiVersion.define_known_versions()
-        shopify.ApiVersion.define_version(shopify.Release('2019-04'))
-        self.session1 = shopify.Session('shop1.myshopify.com', 'unstable', 'token1')
-        self.session2 = shopify.Session('shop2.myshopify.com', '2019-04', 'token2')
+        shopify.ApiVersion.define_version(shopify.Release("2019-04"))
+        self.session1 = shopify.Session("shop1.myshopify.com", "unstable", "token1")
+        self.session2 = shopify.Session("shop2.myshopify.com", "2019-04", "token2")
 
     @classmethod
     def tearDownClass(self):
@@ -27,18 +27,18 @@ class BaseTest(TestCase):
         shopify.ShopifyResource.activate_session(self.session1)
 
         self.assertIsNone(ActiveResource.site)
-        self.assertEqual('https://shop1.myshopify.com/admin/api/unstable', shopify.ShopifyResource.site)
-        self.assertEqual('https://shop1.myshopify.com/admin/api/unstable', shopify.Shop.site)
+        self.assertEqual("https://shop1.myshopify.com/admin/api/unstable", shopify.ShopifyResource.site)
+        self.assertEqual("https://shop1.myshopify.com/admin/api/unstable", shopify.Shop.site)
         self.assertIsNone(ActiveResource.headers)
-        self.assertEqual('token1', shopify.ShopifyResource.headers['X-Shopify-Access-Token'])
-        self.assertEqual('token1', shopify.Shop.headers['X-Shopify-Access-Token'])
+        self.assertEqual("token1", shopify.ShopifyResource.headers["X-Shopify-Access-Token"])
+        self.assertEqual("token1", shopify.Shop.headers["X-Shopify-Access-Token"])
 
     def test_activate_session_should_set_site_given_version(self):
         shopify.ShopifyResource.activate_session(self.session2)
 
         self.assertIsNone(ActiveResource.site)
-        self.assertEqual('https://shop2.myshopify.com/admin/api/2019-04', shopify.ShopifyResource.site)
-        self.assertEqual('https://shop2.myshopify.com/admin/api/2019-04', shopify.Shop.site)
+        self.assertEqual("https://shop2.myshopify.com/admin/api/2019-04", shopify.ShopifyResource.site)
+        self.assertEqual("https://shop2.myshopify.com/admin/api/2019-04", shopify.Shop.site)
         self.assertIsNone(ActiveResource.headers)
 
     def test_clear_session_should_clear_site_and_headers_from_Base(self):
@@ -50,8 +50,8 @@ class BaseTest(TestCase):
         self.assertIsNone(shopify.Shop.site)
 
         self.assertIsNone(ActiveResource.headers)
-        self.assertFalse('X-Shopify-Access-Token' in shopify.ShopifyResource.headers)
-        self.assertFalse('X-Shopify-Access-Token' in shopify.Shop.headers)
+        self.assertFalse("X-Shopify-Access-Token" in shopify.ShopifyResource.headers)
+        self.assertFalse("X-Shopify-Access-Token" in shopify.Shop.headers)
 
     def test_activate_session_with_one_session_then_clearing_and_activating_with_another_session_shoul_request_to_correct_shop(
         self,
@@ -61,57 +61,57 @@ class BaseTest(TestCase):
         shopify.ShopifyResource.activate_session(self.session2)
 
         self.assertIsNone(ActiveResource.site)
-        self.assertEqual('https://shop2.myshopify.com/admin/api/2019-04', shopify.ShopifyResource.site)
-        self.assertEqual('https://shop2.myshopify.com/admin/api/2019-04', shopify.Shop.site)
+        self.assertEqual("https://shop2.myshopify.com/admin/api/2019-04", shopify.ShopifyResource.site)
+        self.assertEqual("https://shop2.myshopify.com/admin/api/2019-04", shopify.Shop.site)
 
         self.assertIsNone(ActiveResource.headers)
-        self.assertEqual('token2', shopify.ShopifyResource.headers['X-Shopify-Access-Token'])
-        self.assertEqual('token2', shopify.Shop.headers['X-Shopify-Access-Token'])
+        self.assertEqual("token2", shopify.ShopifyResource.headers["X-Shopify-Access-Token"])
+        self.assertEqual("token2", shopify.Shop.headers["X-Shopify-Access-Token"])
 
     def test_delete_should_send_custom_headers_with_request(self):
         shopify.ShopifyResource.activate_session(self.session1)
 
         org_headers = shopify.ShopifyResource.headers
-        shopify.ShopifyResource.set_headers({'X-Custom': 'abc'})
+        shopify.ShopifyResource.set_headers({"X-Custom": "abc"})
 
-        with patch('shopify.ShopifyResource.connection.delete') as mock:
-            url = shopify.ShopifyResource._custom_method_collection_url('1', {})
-            shopify.ShopifyResource.delete('1')
-            mock.assert_called_with(url, {'X-Custom': 'abc'})
+        with patch("shopify.ShopifyResource.connection.delete") as mock:
+            url = shopify.ShopifyResource._custom_method_collection_url("1", {})
+            shopify.ShopifyResource.delete("1")
+            mock.assert_called_with(url, {"X-Custom": "abc"})
 
         shopify.ShopifyResource.set_headers(org_headers)
 
     def test_headers_includes_user_agent(self):
-        self.assertTrue('User-Agent' in shopify.ShopifyResource.headers)
-        t = threading.Thread(target=lambda: self.assertTrue('User-Agent' in shopify.ShopifyResource.headers))
+        self.assertTrue("User-Agent" in shopify.ShopifyResource.headers)
+        t = threading.Thread(target=lambda: self.assertTrue("User-Agent" in shopify.ShopifyResource.headers))
         t.start()
         t.join()
 
     def test_headers_is_thread_safe(self):
         def testFunc():
-            shopify.ShopifyResource.headers['X-Custom'] = 'abc'
-            self.assertTrue('X-Custom' in shopify.ShopifyResource.headers)
+            shopify.ShopifyResource.headers["X-Custom"] = "abc"
+            self.assertTrue("X-Custom" in shopify.ShopifyResource.headers)
 
         t1 = threading.Thread(target=testFunc)
         t1.start()
         t1.join()
 
-        t2 = threading.Thread(target=lambda: self.assertFalse('X-Custom' in shopify.ShopifyResource.headers))
+        t2 = threading.Thread(target=lambda: self.assertFalse("X-Custom" in shopify.ShopifyResource.headers))
         t2.start()
         t2.join()
 
     def test_setting_with_user_and_pass_strips_them(self):
         shopify.ShopifyResource.clear_session()
         self.fake(
-            'shop',
-            url='https://this-is-my-test-show.myshopify.com/admin/shop.json',
-            method='GET',
-            body=self.load_fixture('shop'),
-            headers={'Authorization': u'Basic dXNlcjpwYXNz'},
+            "shop",
+            url="https://this-is-my-test-show.myshopify.com/admin/shop.json",
+            method="GET",
+            body=self.load_fixture("shop"),
+            headers={"Authorization": u"Basic dXNlcjpwYXNz"},
         )
-        API_KEY = 'user'
-        PASSWORD = 'pass'
+        API_KEY = "user"
+        PASSWORD = "pass"
         shop_url = "https://%s:%s@this-is-my-test-show.myshopify.com/admin" % (API_KEY, PASSWORD)
         shopify.ShopifyResource.set_site(shop_url)
         res = shopify.Shop.current()
-        self.assertEqual('Apple Computers', res.name)
+        self.assertEqual("Apple Computers", res.name)

--- a/test/blog_test.py
+++ b/test/blog_test.py
@@ -5,11 +5,11 @@ from test.test_helper import TestCase
 class BlogTest(TestCase):
     def test_blog_creation(self):
         self.fake(
-            'blogs',
-            method='POST',
+            "blogs",
+            method="POST",
             code=202,
-            body=self.load_fixture('blog'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("blog"),
+            headers={"Content-type": "application/json"},
         )
-        blog = shopify.Blog.create({'title': "Test Blog"})
+        blog = shopify.Blog.create({"title": "Test Blog"})
         self.assertEqual("Test Blog", blog.title)

--- a/test/carrier_service_test.py
+++ b/test/carrier_service_test.py
@@ -6,16 +6,16 @@ class CarrierServiceTest(TestCase):
     def test_create_new_carrier_service(self):
         self.fake(
             "carrier_services",
-            method='POST',
-            body=self.load_fixture('carrier_service'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("carrier_service"),
+            headers={"Content-type": "application/json"},
         )
 
-        carrier_service = shopify.CarrierService.create({'name': "Some Postal Service"})
+        carrier_service = shopify.CarrierService.create({"name": "Some Postal Service"})
         self.assertEqual("Some Postal Service", carrier_service.name)
 
     def test_get_carrier_service(self):
-        self.fake("carrier_services/123456", method='GET', body=self.load_fixture('carrier_service'))
+        self.fake("carrier_services/123456", method="GET", body=self.load_fixture("carrier_service"))
 
         carrier_service = shopify.CarrierService.find(123456)
         self.assertEqual("Some Postal Service", carrier_service.name)
@@ -23,4 +23,4 @@ class CarrierServiceTest(TestCase):
     def test_set_format_attribute(self):
         carrier_service = shopify.CarrierService()
         carrier_service.format = "json"
-        self.assertEqual("json", carrier_service.attributes['format'])
+        self.assertEqual("json", carrier_service.attributes["format"])

--- a/test/cart_test.py
+++ b/test/cart_test.py
@@ -4,10 +4,10 @@ from test.test_helper import TestCase
 
 class CartTest(TestCase):
     def test_all_should_return_all_carts(self):
-        self.fake('carts')
+        self.fake("carts")
         carts = shopify.Cart.find()
         self.assertEqual(2, len(carts))
         self.assertEqual(2, carts[0].id)
         self.assertEqual("3eed8183d4281db6ea82ee2b8f23e9cc", carts[0].token)
         self.assertEqual(1, len(carts[0].line_items))
-        self.assertEqual('test', carts[0].line_items[0].title)
+        self.assertEqual("test", carts[0].line_items[0].title)

--- a/test/checkout_test.py
+++ b/test/checkout_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class CheckoutTest(TestCase):
     def test_all_should_return_all_checkouts(self):
-        self.fake('checkouts')
+        self.fake("checkouts")
         checkouts = shopify.Checkout.find()
         self.assertEqual(1, len(checkouts))
         self.assertEqual(450789469, checkouts[0].id)

--- a/test/collection_listing_test.py
+++ b/test/collection_listing_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class CollectionListingTest(TestCase):
     def test_get_collection_listings(self):
-        self.fake('collection_listings', method='GET', code=200, body=self.load_fixture('collection_listings'))
+        self.fake("collection_listings", method="GET", code=200, body=self.load_fixture("collection_listings"))
 
         collection_listings = shopify.CollectionListing.find()
         self.assertEqual(1, len(collection_listings))
@@ -12,7 +12,7 @@ class CollectionListingTest(TestCase):
         self.assertEqual("Home page", collection_listings[0].title)
 
     def test_get_collection_listing(self):
-        self.fake('collection_listings/1', method='GET', code=200, body=self.load_fixture('collection_listing'))
+        self.fake("collection_listings/1", method="GET", code=200, body=self.load_fixture("collection_listing"))
 
         collection_listing = shopify.CollectionListing.find(1)
 
@@ -20,7 +20,7 @@ class CollectionListingTest(TestCase):
         self.assertEqual("Home page", collection_listing.title)
 
     def test_reload_collection_listing(self):
-        self.fake('collection_listings/1', method='GET', code=200, body=self.load_fixture('collection_listing'))
+        self.fake("collection_listings/1", method="GET", code=200, body=self.load_fixture("collection_listing"))
 
         collection_listing = shopify.CollectionListing()
         collection_listing.collection_id = 1
@@ -31,10 +31,10 @@ class CollectionListingTest(TestCase):
 
     def test_get_collection_listing_product_ids(self):
         self.fake(
-            'collection_listings/1/product_ids',
-            method='GET',
+            "collection_listings/1/product_ids",
+            method="GET",
             code=200,
-            body=self.load_fixture('collection_listing_product_ids'),
+            body=self.load_fixture("collection_listing_product_ids"),
         )
 
         collection_listing = shopify.CollectionListing()

--- a/test/collection_publication_test.py
+++ b/test/collection_publication_test.py
@@ -6,9 +6,9 @@ from test.test_helper import TestCase
 class CollectionPublicationTest(TestCase):
     def test_find_all_collection_publications(self):
         self.fake(
-            'publications/55650051/collection_publications',
-            method='GET',
-            body=self.load_fixture('collection_publications'),
+            "publications/55650051/collection_publications",
+            method="GET",
+            body=self.load_fixture("collection_publications"),
         )
         collection_publications = shopify.CollectionPublication.find(publication_id=55650051)
 
@@ -17,9 +17,9 @@ class CollectionPublicationTest(TestCase):
 
     def test_find_collection_publication(self):
         self.fake(
-            'publications/55650051/collection_publications/96062799894',
-            method='GET',
-            body=self.load_fixture('collection_publication'),
+            "publications/55650051/collection_publications/96062799894",
+            method="GET",
+            body=self.load_fixture("collection_publication"),
             code=200,
         )
         collection_publication = shopify.CollectionPublication.find(96062799894, publication_id=55650051)
@@ -29,27 +29,27 @@ class CollectionPublicationTest(TestCase):
 
     def test_create_collection_publication(self):
         self.fake(
-            'publications/55650051/collection_publications',
-            method='POST',
-            headers={'Content-type': 'application/json'},
-            body=self.load_fixture('collection_publication'),
+            "publications/55650051/collection_publications",
+            method="POST",
+            headers={"Content-type": "application/json"},
+            body=self.load_fixture("collection_publication"),
             code=201,
         )
 
         collection_publication = shopify.CollectionPublication.create(
             {
-                'publication_id': 55650051,
-                'published_at': "2018-01-29T14:06:08-05:00",
-                'published': True,
-                'collection_id': 60941828118,
+                "publication_id": 55650051,
+                "published_at": "2018-01-29T14:06:08-05:00",
+                "published": True,
+                "collection_id": 60941828118,
             }
         )
 
         expected_body = {
-            'collection_publication': {
-                'published_at': "2018-01-29T14:06:08-05:00",
-                'published': True,
-                'collection_id': 60941828118,
+            "collection_publication": {
+                "published_at": "2018-01-29T14:06:08-05:00",
+                "published": True,
+                "collection_id": 60941828118,
             }
         }
 
@@ -57,14 +57,14 @@ class CollectionPublicationTest(TestCase):
 
     def test_destroy_collection_publication(self):
         self.fake(
-            'publications/55650051/collection_publications/96062799894',
-            method='GET',
-            body=self.load_fixture('collection_publication'),
+            "publications/55650051/collection_publications/96062799894",
+            method="GET",
+            body=self.load_fixture("collection_publication"),
             code=200,
         )
         collection_publication = shopify.CollectionPublication.find(96062799894, publication_id=55650051)
 
-        self.fake('publications/55650051/collection_publications/96062799894', method='DELETE', body='{}', code=200)
+        self.fake("publications/55650051/collection_publications/96062799894", method="DELETE", body="{}", code=200)
         collection_publication.destroy()
 
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())

--- a/test/currency_test.py
+++ b/test/currency_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class CurrencyTest(TestCase):
     def test_get_currencies(self):
-        self.fake('currencies', method='GET', code=200, body=self.load_fixture('currencies'))
+        self.fake("currencies", method="GET", code=200, body=self.load_fixture("currencies"))
 
         currencies = shopify.Currency.find()
         self.assertEqual(4, len(currencies))

--- a/test/customer_saved_search_test.py
+++ b/test/customer_saved_search_test.py
@@ -9,21 +9,21 @@ class CustomerSavedSearchTest(TestCase):
 
     def test_get_customers_from_customer_saved_search(self):
         self.fake(
-            'customer_saved_searches/8899730/customers', body=self.load_fixture('customer_saved_search_customers')
+            "customer_saved_searches/8899730/customers", body=self.load_fixture("customer_saved_search_customers")
         )
         self.assertEqual(1, len(self.customer_saved_search.customers()))
         self.assertEqual(112223902, self.customer_saved_search.customers()[0].id)
 
     def test_get_customers_from_customer_saved_search_with_params(self):
         self.fake(
-            'customer_saved_searches/8899730/customers.json?limit=1',
+            "customer_saved_searches/8899730/customers.json?limit=1",
             extension=False,
-            body=self.load_fixture('customer_saved_search_customers'),
+            body=self.load_fixture("customer_saved_search_customers"),
         )
         customers = self.customer_saved_search.customers(limit=1)
         self.assertEqual(1, len(customers))
         self.assertEqual(112223902, customers[0].id)
 
     def load_customer_saved_search(self):
-        self.fake('customer_saved_searches/8899730', body=self.load_fixture('customer_saved_search'))
+        self.fake("customer_saved_searches/8899730", body=self.load_fixture("customer_saved_search"))
         self.customer_saved_search = shopify.CustomerSavedSearch.find(8899730)

--- a/test/customer_test.py
+++ b/test/customer_test.py
@@ -6,24 +6,24 @@ from test.test_helper import TestCase
 class CustomerTest(TestCase):
     def setUp(self):
         super(CustomerTest, self).setUp()
-        self.fake('customers/207119551', method='GET', body=self.load_fixture('customer'))
+        self.fake("customers/207119551", method="GET", body=self.load_fixture("customer"))
         self.customer = shopify.Customer.find(207119551)
 
     def test_create_customer(self):
         self.fake(
-            "customers", method='POST', body=self.load_fixture('customer'), headers={'Content-type': 'application/json'}
+            "customers", method="POST", body=self.load_fixture("customer"), headers={"Content-type": "application/json"}
         )
         customer = shopify.Customer()
-        customer.first_name = 'Bob'
-        customer.last_name = 'Lastnameson'
-        customer.email = 'steve.lastnameson@example.com'
+        customer.first_name = "Bob"
+        customer.last_name = "Lastnameson"
+        customer.email = "steve.lastnameson@example.com"
         customer.verified_email = True
         customer.password = "newpass"
         customer.password_confirmation = "newpass"
-        self.assertEqual("newpass", customer.attributes['password'])
+        self.assertEqual("newpass", customer.attributes["password"])
         customer.save()
         self.assertEqual("Bob", customer.first_name)
-        self.assertEqual("newpass", customer.attributes['password'])
+        self.assertEqual("newpass", customer.attributes["password"])
 
     def test_get_customer(self):
         self.assertEqual("Bob", self.customer.first_name)
@@ -32,44 +32,44 @@ class CustomerTest(TestCase):
         self.fake(
             "customers/search.json?query=Bob+country%3AUnited+States",
             extension=False,
-            body=self.load_fixture('customers_search'),
+            body=self.load_fixture("customers_search"),
         )
 
-        results = shopify.Customer.search(query='Bob country:United States')
-        self.assertEqual('Bob', results[0].first_name)
+        results = shopify.Customer.search(query="Bob country:United States")
+        self.assertEqual("Bob", results[0].first_name)
 
     def test_send_invite_with_no_params(self):
-        customer_invite_fixture = self.load_fixture('customer_invite')
+        customer_invite_fixture = self.load_fixture("customer_invite")
         customer_invite = json.loads(customer_invite_fixture.decode("utf-8"))
         self.fake(
-            'customers/207119551/send_invite',
-            method='POST',
+            "customers/207119551/send_invite",
+            method="POST",
             body=customer_invite_fixture,
-            headers={'Content-type': 'application/json'},
+            headers={"Content-type": "application/json"},
         )
         customer_invite_response = self.customer.send_invite()
         self.assertEqual(json.loads('{"customer_invite": {}}'), json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(customer_invite_response, shopify.CustomerInvite)
-        self.assertEqual(customer_invite['customer_invite']['to'], customer_invite_response.to)
+        self.assertEqual(customer_invite["customer_invite"]["to"], customer_invite_response.to)
 
     def test_send_invite_with_params(self):
-        customer_invite_fixture = self.load_fixture('customer_invite')
+        customer_invite_fixture = self.load_fixture("customer_invite")
         customer_invite = json.loads(customer_invite_fixture.decode("utf-8"))
         self.fake(
-            'customers/207119551/send_invite',
-            method='POST',
+            "customers/207119551/send_invite",
+            method="POST",
             body=customer_invite_fixture,
-            headers={'Content-type': 'application/json'},
+            headers={"Content-type": "application/json"},
         )
-        customer_invite_response = self.customer.send_invite(shopify.CustomerInvite(customer_invite['customer_invite']))
+        customer_invite_response = self.customer.send_invite(shopify.CustomerInvite(customer_invite["customer_invite"]))
         self.assertEqual(customer_invite, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(customer_invite_response, shopify.CustomerInvite)
-        self.assertEqual(customer_invite['customer_invite']['to'], customer_invite_response.to)
+        self.assertEqual(customer_invite["customer_invite"]["to"], customer_invite_response.to)
 
     def test_get_customer_orders(self):
-        self.fake('customers/207119551', method='GET', body=self.load_fixture('customer'))
+        self.fake("customers/207119551", method="GET", body=self.load_fixture("customer"))
         customer = shopify.Customer.find(207119551)
-        self.fake('customers/207119551/orders', method='GET', body=self.load_fixture('orders'))
+        self.fake("customers/207119551/orders", method="GET", body=self.load_fixture("orders"))
         orders = customer.orders()
         self.assertIsInstance(orders[0], shopify.Order)
         self.assertEqual(450789469, orders[0].id)

--- a/test/discount_code_creation_test.py
+++ b/test/discount_code_creation_test.py
@@ -4,14 +4,14 @@ import shopify
 
 class DiscountCodeCreationTest(TestCase):
     def test_find_batch_job_discount_codes(self):
-        self.fake('price_rules/1213131', body=self.load_fixture('price_rule'))
+        self.fake("price_rules/1213131", body=self.load_fixture("price_rule"))
         price_rule = shopify.PriceRule.find(1213131)
 
-        self.fake('price_rules/1213131/batch/989355119', body=self.load_fixture('discount_code_creation'))
+        self.fake("price_rules/1213131/batch/989355119", body=self.load_fixture("discount_code_creation"))
         batch = price_rule.find_batch(989355119)
 
-        self.fake('price_rules/1213131/batch/989355119/discount_codes', body=self.load_fixture('batch_discount_codes'))
+        self.fake("price_rules/1213131/batch/989355119/discount_codes", body=self.load_fixture("batch_discount_codes"))
         discount_codes = batch.discount_codes()
 
-        self.assertEqual('foo', discount_codes[0].code)
-        self.assertEqual('bar', discount_codes[2].code)
+        self.assertEqual("foo", discount_codes[0].code)
+        self.assertEqual("bar", discount_codes[2].code)

--- a/test/discount_code_test.py
+++ b/test/discount_code_test.py
@@ -6,7 +6,7 @@ from test.test_helper import TestCase
 class DiscountCodeTest(TestCase):
     def setUp(self):
         super(DiscountCodeTest, self).setUp()
-        self.fake("price_rules/1213131/discount_codes/34", method='GET', body=self.load_fixture('discount_code'))
+        self.fake("price_rules/1213131/discount_codes/34", method="GET", body=self.load_fixture("discount_code"))
         self.discount_code = shopify.DiscountCode.find(34, price_rule_id=1213131)
 
     def test_find_a_specific_discount_code(self):
@@ -14,18 +14,18 @@ class DiscountCodeTest(TestCase):
         self.assertEqual("25OFF", discount_code.code)
 
     def test_update_a_specific_discount_code(self):
-        self.discount_code.code = 'BOGO'
+        self.discount_code.code = "BOGO"
         self.fake(
-            'price_rules/1213131/discount_codes/34',
-            method='PUT',
+            "price_rules/1213131/discount_codes/34",
+            method="PUT",
             code=200,
-            body=self.load_fixture('discount_code'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("discount_code"),
+            headers={"Content-type": "application/json"},
         )
         self.discount_code.save()
-        self.assertEqual('BOGO', json.loads(self.http.request.data.decode("utf-8"))["discount_code"]["code"])
+        self.assertEqual("BOGO", json.loads(self.http.request.data.decode("utf-8"))["discount_code"]["code"])
 
     def test_delete_a_specific_discount_code(self):
-        self.fake('price_rules/1213131/discount_codes/34', method='DELETE', body='destroyed')
+        self.fake("price_rules/1213131/discount_codes/34", method="DELETE", body="destroyed")
         self.discount_code.destroy()
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())

--- a/test/disputes_test.py
+++ b/test/disputes_test.py
@@ -3,14 +3,14 @@ from test.test_helper import TestCase
 
 
 class DisputeTest(TestCase):
-    prefix = '/admin/api/unstable/shopify_payments'
+    prefix = "/admin/api/unstable/shopify_payments"
 
     def test_get_dispute(self):
-        self.fake('disputes', method='GET', prefix=self.prefix, body=self.load_fixture('disputes'))
+        self.fake("disputes", method="GET", prefix=self.prefix, body=self.load_fixture("disputes"))
         disputes = shopify.Disputes.find()
         self.assertGreater(len(disputes), 0)
 
     def test_get_one_dispute(self):
-        self.fake('disputes/1052608616', method='GET', prefix=self.prefix, body=self.load_fixture('dispute'))
+        self.fake("disputes/1052608616", method="GET", prefix=self.prefix, body=self.load_fixture("dispute"))
         disputes = shopify.Disputes.find(1052608616)
-        self.assertEqual('won', disputes.status)
+        self.assertEqual("won", disputes.status)

--- a/test/draft_order_test.py
+++ b/test/draft_order_test.py
@@ -6,32 +6,32 @@ import json
 class DraftOrderTest(TestCase):
     def setUp(self):
         super(DraftOrderTest, self).setUp()
-        self.fake('draft_orders/517119332', body=self.load_fixture('draft_order'))
+        self.fake("draft_orders/517119332", body=self.load_fixture("draft_order"))
         self.draft_order = shopify.DraftOrder.find(517119332)
 
     def test_get_draft_order(self):
-        self.fake('draft_orders/517119332', method='GET', code=200, body=self.load_fixture('draft_order'))
+        self.fake("draft_orders/517119332", method="GET", code=200, body=self.load_fixture("draft_order"))
         draft_order = shopify.DraftOrder.find(517119332)
         self.assertEqual(517119332, draft_order.id)
 
     def test_get_all_draft_orders(self):
-        self.fake('draft_orders', method='GET', code=200, body=self.load_fixture('draft_orders'))
+        self.fake("draft_orders", method="GET", code=200, body=self.load_fixture("draft_orders"))
         draft_orders = shopify.DraftOrder.find()
         self.assertEqual(1, len(draft_orders))
         self.assertEqual(517119332, draft_orders[0].id)
 
     def test_get_count_draft_orders(self):
-        self.fake('draft_orders/count', method='GET', code=200, body='{"count": 16}')
+        self.fake("draft_orders/count", method="GET", code=200, body='{"count": 16}')
         draft_orders_count = shopify.DraftOrder.count()
         self.assertEqual(16, draft_orders_count)
 
     def test_create_draft_order(self):
         self.fake(
-            'draft_orders',
-            method='POST',
+            "draft_orders",
+            method="POST",
             code=201,
-            body=self.load_fixture('draft_order'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("draft_order"),
+            headers={"Content-type": "application/json"},
         )
         draft_order = shopify.DraftOrder.create({"line_items": [{"quantity": 1, "variant_id": 39072856}]})
         self.assertEqual(
@@ -41,73 +41,73 @@ class DraftOrderTest(TestCase):
 
     def test_create_draft_order_202(self):
         self.fake(
-            'draft_orders',
-            method='POST',
+            "draft_orders",
+            method="POST",
             code=202,
-            body=self.load_fixture('draft_order'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("draft_order"),
+            headers={"Content-type": "application/json"},
         )
         draft_order = shopify.DraftOrder.create({"line_items": [{"quantity": 1, "variant_id": 39072856}]})
         self.assertEqual(39072856, draft_order.line_items[0].variant_id)
 
     def test_update_draft_order(self):
-        self.draft_order.note = 'Test new note'
+        self.draft_order.note = "Test new note"
         self.fake(
-            'draft_orders/517119332',
-            method='PUT',
+            "draft_orders/517119332",
+            method="PUT",
             code=200,
-            body=self.load_fixture('draft_order'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("draft_order"),
+            headers={"Content-type": "application/json"},
         )
         self.draft_order.save()
-        self.assertEqual('Test new note', json.loads(self.http.request.data.decode("utf-8"))['draft_order']['note'])
+        self.assertEqual("Test new note", json.loads(self.http.request.data.decode("utf-8"))["draft_order"]["note"])
 
     def test_send_invoice_with_no_params(self):
-        draft_order_invoice_fixture = self.load_fixture('draft_order_invoice')
+        draft_order_invoice_fixture = self.load_fixture("draft_order_invoice")
         draft_order_invoice = json.loads(draft_order_invoice_fixture.decode("utf-8"))
         self.fake(
-            'draft_orders/517119332/send_invoice',
-            method='POST',
+            "draft_orders/517119332/send_invoice",
+            method="POST",
             body=draft_order_invoice_fixture,
-            headers={'Content-type': 'application/json'},
+            headers={"Content-type": "application/json"},
         )
         draft_order_invoice_response = self.draft_order.send_invoice()
         self.assertEqual(json.loads('{"draft_order_invoice": {}}'), json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(draft_order_invoice_response, shopify.DraftOrderInvoice)
-        self.assertEqual(draft_order_invoice['draft_order_invoice']['to'], draft_order_invoice_response.to)
+        self.assertEqual(draft_order_invoice["draft_order_invoice"]["to"], draft_order_invoice_response.to)
 
     def test_send_invoice_with_params(self):
-        draft_order_invoice_fixture = self.load_fixture('draft_order_invoice')
+        draft_order_invoice_fixture = self.load_fixture("draft_order_invoice")
         draft_order_invoice = json.loads(draft_order_invoice_fixture.decode("utf-8"))
         self.fake(
-            'draft_orders/517119332/send_invoice',
-            method='POST',
+            "draft_orders/517119332/send_invoice",
+            method="POST",
             body=draft_order_invoice_fixture,
-            headers={'Content-type': 'application/json'},
+            headers={"Content-type": "application/json"},
         )
         draft_order_invoice_response = self.draft_order.send_invoice(
-            shopify.DraftOrderInvoice(draft_order_invoice['draft_order_invoice'])
+            shopify.DraftOrderInvoice(draft_order_invoice["draft_order_invoice"])
         )
         self.assertEqual(draft_order_invoice, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(draft_order_invoice_response, shopify.DraftOrderInvoice)
-        self.assertEqual(draft_order_invoice['draft_order_invoice']['to'], draft_order_invoice_response.to)
+        self.assertEqual(draft_order_invoice["draft_order_invoice"]["to"], draft_order_invoice_response.to)
 
     def test_delete_draft_order(self):
-        self.fake('draft_orders/517119332', method='DELETE', body='destroyed')
+        self.fake("draft_orders/517119332", method="DELETE", body="destroyed")
         self.draft_order.destroy()
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())
 
     def test_add_metafields_to_draft_order(self):
         self.fake(
-            'draft_orders/517119332/metafields',
-            method='POST',
+            "draft_orders/517119332/metafields",
+            method="POST",
             code=201,
-            body=self.load_fixture('metafield'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("metafield"),
+            headers={"Content-type": "application/json"},
         )
         field = self.draft_order.add_metafield(
             shopify.Metafield(
-                {'namespace': 'contact', 'key': 'email', 'value': '123@example.com', 'value_type': 'string'}
+                {"namespace": "contact", "key": "email", "value": "123@example.com", "value_type": "string"}
             )
         )
         self.assertEqual(
@@ -117,34 +117,34 @@ class DraftOrderTest(TestCase):
             json.loads(self.http.request.data.decode("utf-8")),
         )
         self.assertFalse(field.is_new())
-        self.assertEqual('contact', field.namespace)
-        self.assertEqual('email', field.key)
-        self.assertEqual('123@example.com', field.value)
+        self.assertEqual("contact", field.namespace)
+        self.assertEqual("email", field.key)
+        self.assertEqual("123@example.com", field.value)
 
     def test_get_metafields_for_draft_order(self):
-        self.fake('draft_orders/517119332/metafields', body=self.load_fixture('metafields'))
+        self.fake("draft_orders/517119332/metafields", body=self.load_fixture("metafields"))
         metafields = self.draft_order.metafields()
         self.assertEqual(2, len(metafields))
         self.assertIsInstance(metafields[0], shopify.Metafield)
         self.assertIsInstance(metafields[1], shopify.Metafield)
 
     def test_complete_draft_order_with_no_params(self):
-        completed_fixture = self.load_fixture('draft_order_completed')
-        completed_draft = json.loads(completed_fixture.decode("utf-8"))['draft_order']
-        headers = {'Content-type': 'application/json', 'Content-length': '0'}
-        self.fake('draft_orders/517119332/complete', method='PUT', body=completed_fixture, headers=headers)
+        completed_fixture = self.load_fixture("draft_order_completed")
+        completed_draft = json.loads(completed_fixture.decode("utf-8"))["draft_order"]
+        headers = {"Content-type": "application/json", "Content-length": "0"}
+        self.fake("draft_orders/517119332/complete", method="PUT", body=completed_fixture, headers=headers)
         self.draft_order.complete()
-        self.assertEqual(completed_draft['status'], self.draft_order.status)
-        self.assertEqual(completed_draft['order_id'], self.draft_order.order_id)
+        self.assertEqual(completed_draft["status"], self.draft_order.status)
+        self.assertEqual(completed_draft["order_id"], self.draft_order.order_id)
         self.assertIsNotNone(self.draft_order.completed_at)
 
     def test_complete_draft_order_with_params(self):
-        completed_fixture = self.load_fixture('draft_order_completed')
-        completed_draft = json.loads(completed_fixture.decode("utf-8"))['draft_order']
-        headers = {'Content-type': 'application/json', 'Content-length': '0'}
-        url = 'draft_orders/517119332/complete.json?payment_pending=true'
-        self.fake(url, extension=False, method='PUT', body=completed_fixture, headers=headers)
-        self.draft_order.complete({'payment_pending': True})
-        self.assertEqual(completed_draft['status'], self.draft_order.status)
-        self.assertEqual(completed_draft['order_id'], self.draft_order.order_id)
+        completed_fixture = self.load_fixture("draft_order_completed")
+        completed_draft = json.loads(completed_fixture.decode("utf-8"))["draft_order"]
+        headers = {"Content-type": "application/json", "Content-length": "0"}
+        url = "draft_orders/517119332/complete.json?payment_pending=true"
+        self.fake(url, extension=False, method="PUT", body=completed_fixture, headers=headers)
+        self.draft_order.complete({"payment_pending": True})
+        self.assertEqual(completed_draft["status"], self.draft_order.status)
+        self.assertEqual(completed_draft["order_id"], self.draft_order.order_id)
         self.assertIsNotNone(self.draft_order.completed_at)

--- a/test/event_test.py
+++ b/test/event_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class EventTest(TestCase):
     def test_prefix_uses_resource(self):
-        prefix = shopify.Event._prefix(options={'resource': "orders", "resource_id": 42})
+        prefix = shopify.Event._prefix(options={"resource": "orders", "resource_id": 42})
         self.assertEqual("https://this-is-my-test-show.myshopify.com/admin/api/unstable/orders/42", prefix)
 
     def test_prefix_doesnt_need_resource(self):

--- a/test/fulfillment_event_test.py
+++ b/test/fulfillment_event_test.py
@@ -6,8 +6,8 @@ class FulFillmentEventTest(TestCase):
     def test_get_fulfillment_event(self):
         self.fake(
             "orders/2776493818019/fulfillments/2608403447971/events",
-            method='GET',
-            body=self.load_fixture('fulfillment_event'),
+            method="GET",
+            body=self.load_fixture("fulfillment_event"),
         )
         fulfillment_event = shopify.FulfillmentEvent.find(order_id=2776493818019, fulfillment_id=2608403447971)
         self.assertEqual(1, len(fulfillment_event))
@@ -15,26 +15,26 @@ class FulFillmentEventTest(TestCase):
     def test_create_fulfillment_event(self):
         self.fake(
             "orders/2776493818019/fulfillments/2608403447971/events",
-            method='POST',
-            body=self.load_fixture('fulfillment_event'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("fulfillment_event"),
+            headers={"Content-type": "application/json"},
         )
         new_fulfillment_event = shopify.FulfillmentEvent(
-            {'order_id': '2776493818019', 'fulfillment_id': '2608403447971'}
+            {"order_id": "2776493818019", "fulfillment_id": "2608403447971"}
         )
-        new_fulfillment_event.status = 'ready_for_pickup'
+        new_fulfillment_event.status = "ready_for_pickup"
         new_fulfillment_event.save()
 
     def test_error_on_incorrect_status(self):
         with self.assertRaises(AttributeError):
             self.fake(
                 "orders/2776493818019/fulfillments/2608403447971/events/12584341209251",
-                method='GET',
-                body=self.load_fixture('fulfillment_event'),
+                method="GET",
+                body=self.load_fixture("fulfillment_event"),
             )
-            incorrect_status = 'asdf'
+            incorrect_status = "asdf"
             fulfillment_event = shopify.FulfillmentEvent.find(
-                12584341209251, order_id='2776493818019', fulfillment_id='2608403447971'
+                12584341209251, order_id="2776493818019", fulfillment_id="2608403447971"
             )
             fulfillment_event.status = incorrect_status
             fulfillment_event.save()

--- a/test/fulfillment_service_test.py
+++ b/test/fulfillment_service_test.py
@@ -6,16 +6,16 @@ class FulfillmentServiceTest(TestCase):
     def test_create_new_fulfillment_service(self):
         self.fake(
             "fulfillment_services",
-            method='POST',
-            body=self.load_fixture('fulfillment_service'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("fulfillment_service"),
+            headers={"Content-type": "application/json"},
         )
 
-        fulfillment_service = shopify.FulfillmentService.create({'name': "SomeService"})
+        fulfillment_service = shopify.FulfillmentService.create({"name": "SomeService"})
         self.assertEqual("SomeService", fulfillment_service.name)
 
     def test_get_fulfillment_service(self):
-        self.fake("fulfillment_services/123456", method='GET', body=self.load_fixture('fulfillment_service'))
+        self.fake("fulfillment_services/123456", method="GET", body=self.load_fixture("fulfillment_service"))
 
         fulfillment_service = shopify.FulfillmentService.find(123456)
         self.assertEqual("SomeService", fulfillment_service.name)
@@ -23,4 +23,4 @@ class FulfillmentServiceTest(TestCase):
     def test_set_format_attribute(self):
         fulfillment_service = shopify.FulfillmentService()
         fulfillment_service.format = "json"
-        self.assertEqual("json", fulfillment_service.attributes['format'])
+        self.assertEqual("json", fulfillment_service.attributes["format"])

--- a/test/fulfillment_test.py
+++ b/test/fulfillment_test.py
@@ -6,55 +6,55 @@ from pyactiveresource.activeresource import ActiveResource
 class FulFillmentTest(TestCase):
     def setUp(self):
         super(FulFillmentTest, self).setUp()
-        self.fake("orders/450789469/fulfillments/255858046", method='GET', body=self.load_fixture('fulfillment'))
+        self.fake("orders/450789469/fulfillments/255858046", method="GET", body=self.load_fixture("fulfillment"))
 
     def test_able_to_open_fulfillment(self):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
-        success = self.load_fixture('fulfillment')
-        success = success.replace(b'pending', b'open')
+        success = self.load_fixture("fulfillment")
+        success = success.replace(b"pending", b"open")
         self.fake(
             "orders/450789469/fulfillments/255858046/open",
-            method='POST',
-            headers={'Content-length': '0', 'Content-type': 'application/json'},
+            method="POST",
+            headers={"Content-length": "0", "Content-type": "application/json"},
             body=success,
         )
 
-        self.assertEqual('pending', fulfillment.status)
+        self.assertEqual("pending", fulfillment.status)
         fulfillment.open()
-        self.assertEqual('open', fulfillment.status)
+        self.assertEqual("open", fulfillment.status)
 
     def test_able_to_complete_fulfillment(self):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
-        success = self.load_fixture('fulfillment')
-        success = success.replace(b'pending', b'success')
+        success = self.load_fixture("fulfillment")
+        success = success.replace(b"pending", b"success")
         self.fake(
             "orders/450789469/fulfillments/255858046/complete",
-            method='POST',
-            headers={'Content-length': '0', 'Content-type': 'application/json'},
+            method="POST",
+            headers={"Content-length": "0", "Content-type": "application/json"},
             body=success,
         )
 
-        self.assertEqual('pending', fulfillment.status)
+        self.assertEqual("pending", fulfillment.status)
         fulfillment.complete()
-        self.assertEqual('success', fulfillment.status)
+        self.assertEqual("success", fulfillment.status)
 
     def test_able_to_cancel_fulfillment(self):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
 
-        cancelled = self.load_fixture('fulfillment')
-        cancelled = cancelled.replace(b'pending', b'cancelled')
+        cancelled = self.load_fixture("fulfillment")
+        cancelled = cancelled.replace(b"pending", b"cancelled")
         self.fake(
             "orders/450789469/fulfillments/255858046/cancel",
-            method='POST',
-            headers={'Content-length': '0', 'Content-type': 'application/json'},
+            method="POST",
+            headers={"Content-length": "0", "Content-type": "application/json"},
             body=cancelled,
         )
 
-        self.assertEqual('pending', fulfillment.status)
+        self.assertEqual("pending", fulfillment.status)
         fulfillment.cancel()
-        self.assertEqual('cancelled', fulfillment.status)
+        self.assertEqual("cancelled", fulfillment.status)
 
     def test_update_tracking(self):
         fulfillment = shopify.Fulfillment.find(255858046, order_id=450789469)
@@ -62,15 +62,15 @@ class FulFillmentTest(TestCase):
         tracking_info = {"number": 1111, "url": "http://www.my-url.com", "company": "my-company"}
         notify_customer = False
 
-        update_tracking = self.load_fixture('fulfillment')
-        update_tracking = update_tracking.replace(b'null-company', b'my-company')
-        update_tracking = update_tracking.replace(b'http://www.google.com/search?q=1Z2345', b'http://www.my-url.com')
-        update_tracking = update_tracking.replace(b'1Z2345', b'1111')
+        update_tracking = self.load_fixture("fulfillment")
+        update_tracking = update_tracking.replace(b"null-company", b"my-company")
+        update_tracking = update_tracking.replace(b"http://www.google.com/search?q=1Z2345", b"http://www.my-url.com")
+        update_tracking = update_tracking.replace(b"1Z2345", b"1111")
 
         self.fake(
             "fulfillments/255858046/update_tracking",
             method="POST",
-            headers={'Content-type': 'application/json'},
+            headers={"Content-type": "application/json"},
             body=update_tracking,
         )
 
@@ -79,5 +79,5 @@ class FulFillmentTest(TestCase):
         self.assertEqual("http://www.google.com/search?q=1Z2345", fulfillment.tracking_url)
         fulfillment.update_tracking(tracking_info, notify_customer)
         self.assertEqual("my-company", fulfillment.tracking_company)
-        self.assertEqual('1111', fulfillment.tracking_number)
-        self.assertEqual('http://www.my-url.com', fulfillment.tracking_url)
+        self.assertEqual("1111", fulfillment.tracking_number)
+        self.assertEqual("http://www.my-url.com", fulfillment.tracking_url)

--- a/test/gift_card_test.py
+++ b/test/gift_card_test.py
@@ -6,29 +6,29 @@ from test.test_helper import TestCase
 class GiftCardTest(TestCase):
     def test_gift_card_creation(self):
         self.fake(
-            'gift_cards',
-            method='POST',
+            "gift_cards",
+            method="POST",
             code=202,
-            body=self.load_fixture('gift_card'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("gift_card"),
+            headers={"Content-type": "application/json"},
         )
-        gift_card = shopify.GiftCard.create({'code': 'd7a2bcggda89c293', 'note': "Gift card note."})
+        gift_card = shopify.GiftCard.create({"code": "d7a2bcggda89c293", "note": "Gift card note."})
         self.assertEqual("Gift card note.", gift_card.note)
         self.assertEqual("c293", gift_card.last_characters)
 
     def test_fetch_gift_cards(self):
-        self.fake('gift_cards', method='GET', code=200, body=self.load_fixture('gift_cards'))
+        self.fake("gift_cards", method="GET", code=200, body=self.load_fixture("gift_cards"))
         gift_cards = shopify.GiftCard.find()
         self.assertEqual(1, len(gift_cards))
 
     def test_disable_gift_card(self):
-        self.fake('gift_cards/4208208', method='GET', code=200, body=self.load_fixture('gift_card'))
+        self.fake("gift_cards/4208208", method="GET", code=200, body=self.load_fixture("gift_card"))
         self.fake(
-            'gift_cards/4208208/disable',
-            method='POST',
+            "gift_cards/4208208/disable",
+            method="POST",
             code=200,
-            body=self.load_fixture('gift_card_disabled'),
-            headers={'Content-length': '0', 'Content-type': 'application/json'},
+            body=self.load_fixture("gift_card_disabled"),
+            headers={"Content-length": "0", "Content-type": "application/json"},
         )
         gift_card = shopify.GiftCard.find(4208208)
         self.assertFalse(gift_card.disabled_at)
@@ -36,20 +36,20 @@ class GiftCardTest(TestCase):
         self.assertTrue(gift_card.disabled_at)
 
     def test_adjust_gift_card(self):
-        self.fake('gift_cards/4208208', method='GET', code=200, body=self.load_fixture('gift_card'))
+        self.fake("gift_cards/4208208", method="GET", code=200, body=self.load_fixture("gift_card"))
         self.fake(
-            'gift_cards/4208208/adjustments',
-            method='POST',
+            "gift_cards/4208208/adjustments",
+            method="POST",
             code=201,
-            body=self.load_fixture('gift_card_adjustment'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("gift_card_adjustment"),
+            headers={"Content-type": "application/json"},
         )
         gift_card = shopify.GiftCard.find(4208208)
         self.assertEqual(gift_card.balance, "25.00")
         adjustment = gift_card.add_adjustment(
             shopify.GiftCardAdjustment(
                 {
-                    'amount': 100,
+                    "amount": 100,
                 }
             )
         )
@@ -58,8 +58,8 @@ class GiftCardTest(TestCase):
 
     def test_search(self):
         self.fake(
-            "gift_cards/search.json?query=balance%3A10", extension=False, body=self.load_fixture('gift_cards_search')
+            "gift_cards/search.json?query=balance%3A10", extension=False, body=self.load_fixture("gift_cards_search")
         )
 
-        results = shopify.GiftCard.search(query='balance:10')
+        results = shopify.GiftCard.search(query="balance:10")
         self.assertEqual(results[0].balance, "10.00")

--- a/test/graphql_test.py
+++ b/test/graphql_test.py
@@ -7,28 +7,28 @@ class GraphQLTest(TestCase):
     def setUp(self):
         super(GraphQLTest, self).setUp()
         shopify.ApiVersion.define_known_versions()
-        shopify_session = shopify.Session('this-is-my-test-show.myshopify.com', 'unstable', 'token')
+        shopify_session = shopify.Session("this-is-my-test-show.myshopify.com", "unstable", "token")
         shopify.ShopifyResource.activate_session(shopify_session)
         client = shopify.GraphQL()
         self.fake(
-            'graphql',
-            method='POST',
+            "graphql",
+            method="POST",
             code=201,
             headers={
-                'X-Shopify-Access-Token': 'token',
-                'Accept': 'application/json',
-                'Content-Type': 'application/json',
+                "X-Shopify-Access-Token": "token",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
             },
         )
-        query = '''
+        query = """
             {
                 shop {
                     name
                     id
                 }
             }
-        '''
+        """
         self.result = client.execute(query)
 
     def test_fetch_shop_with_graphql(self):
-        self.assertTrue(json.loads(self.result)['shop']['name'] == 'Apple Computers')
+        self.assertTrue(json.loads(self.result)["shop"]["name"] == "Apple Computers")

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -7,38 +7,38 @@ class ImageTest(TestCase):
     def test_create_image(self):
         self.fake(
             "products/632910392/images",
-            method='POST',
-            body=self.load_fixture('image'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("image"),
+            headers={"Content-type": "application/json"},
         )
-        image = shopify.Image({'product_id': 632910392})
+        image = shopify.Image({"product_id": 632910392})
         image.position = 1
         image.attachment = "R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf=="
         image.save()
 
         self.assertEqual(
-            'http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540', image.src
+            "http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540", image.src
         )
         self.assertEqual(850703190, image.id)
 
     def test_attach_image(self):
         self.fake(
             "products/632910392/images",
-            method='POST',
-            body=self.load_fixture('image'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("image"),
+            headers={"Content-type": "application/json"},
         )
-        image = shopify.Image({'product_id': 632910392})
+        image = shopify.Image({"product_id": 632910392})
         image.position = 1
         binary_in = base64.b64decode(
             "R0lGODlhbgCMAPf/APbr48VySrxTO7IgKt2qmKQdJeK8lsFjROG5p/nz7Zg3MNmnd7Q1MLNVS9GId71hSJMZIuzTu4UtKbeEeakhKMl8U8WYjfr18YQaIbAf=="
         )
-        image.attach_image(data=binary_in, filename='ipod-nano.png')
+        image.attach_image(data=binary_in, filename="ipod-nano.png")
         image.save()
         binary_out = base64.b64decode(image.attachment)
 
         self.assertEqual(
-            'http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540', image.src
+            "http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540", image.src
         )
         self.assertEqual(850703190, image.id)
         self.assertEqual(binary_in, binary_out)
@@ -46,9 +46,9 @@ class ImageTest(TestCase):
     def test_create_image_then_add_parent_id(self):
         self.fake(
             "products/632910392/images",
-            method='POST',
-            body=self.load_fixture('image'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("image"),
+            headers={"Content-type": "application/json"},
         )
         image = shopify.Image()
         image.position = 1
@@ -57,25 +57,25 @@ class ImageTest(TestCase):
         image.save()
 
         self.assertEqual(
-            'http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540', image.src
+            "http://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1389388540", image.src
         )
         self.assertEqual(850703190, image.id)
 
     def test_get_images(self):
-        self.fake("products/632910392/images", method='GET', body=self.load_fixture('images'))
+        self.fake("products/632910392/images", method="GET", body=self.load_fixture("images"))
         image = shopify.Image.find(product_id=632910392)
         self.assertEqual(2, len(image))
 
     def test_get_image(self):
-        self.fake("products/632910392/images/850703190", method='GET', body=self.load_fixture('image'))
+        self.fake("products/632910392/images/850703190", method="GET", body=self.load_fixture("image"))
         image = shopify.Image.find(850703190, product_id=632910392)
         self.assertEqual(850703190, image.id)
 
     def test_get_metafields_for_image(self):
-        fake_extension = 'json?metafield[owner_id]=850703190&metafield[owner_resource]=product_image'
-        self.fake("metafields", method='GET', extension=fake_extension, body=self.load_fixture('image_metafields'))
+        fake_extension = "json?metafield[owner_id]=850703190&metafield[owner_resource]=product_image"
+        self.fake("metafields", method="GET", extension=fake_extension, body=self.load_fixture("image_metafields"))
 
-        image = shopify.Image(attributes={'id': 850703190, 'product_id': 632910392})
+        image = shopify.Image(attributes={"id": 850703190, "product_id": 632910392})
         metafields = image.metafields()
 
         self.assertEqual(1, len(metafields))

--- a/test/inventory_item_test.py
+++ b/test/inventory_item_test.py
@@ -4,16 +4,16 @@ from test.test_helper import TestCase
 
 class InventoryItemTest(TestCase):
     def test_fetch_inventory_item(self):
-        self.fake('inventory_items/123456789', method='GET', body=self.load_fixture('inventory_item'))
+        self.fake("inventory_items/123456789", method="GET", body=self.load_fixture("inventory_item"))
         inventory_item = shopify.InventoryItem.find(123456789)
         self.assertEqual(inventory_item.sku, "IPOD2008PINK")
 
     def test_fetch_inventory_item_ids(self):
         self.fake(
-            'inventory_items.json?ids=123456789%2C234567891',
-            extension='',
-            method='GET',
-            body=self.load_fixture('inventory_items'),
+            "inventory_items.json?ids=123456789%2C234567891",
+            extension="",
+            method="GET",
+            body=self.load_fixture("inventory_items"),
         )
-        inventory_items = shopify.InventoryItem.find(ids='123456789,234567891')
+        inventory_items = shopify.InventoryItem.find(ids="123456789,234567891")
         self.assertEqual(3, len(inventory_items))

--- a/test/inventory_level_test.py
+++ b/test/inventory_level_test.py
@@ -6,40 +6,40 @@ from test.test_helper import TestCase
 
 class InventoryLevelTest(TestCase):
     def test_fetch_inventory_level(self):
-        params = {'inventory_item_ids': [808950810, 39072856], 'location_ids': [905684977, 487838322]}
+        params = {"inventory_item_ids": [808950810, 39072856], "location_ids": [905684977, 487838322]}
 
         self.fake(
-            'inventory_levels.json?location_ids=905684977%2C487838322&inventory_item_ids=808950810%2C39072856',
-            method='GET',
-            extension='',
-            body=self.load_fixture('inventory_levels'),
+            "inventory_levels.json?location_ids=905684977%2C487838322&inventory_item_ids=808950810%2C39072856",
+            method="GET",
+            extension="",
+            body=self.load_fixture("inventory_levels"),
         )
         inventory_levels = shopify.InventoryLevel.find(
-            inventory_item_ids='808950810,39072856', location_ids='905684977,487838322'
+            inventory_item_ids="808950810,39072856", location_ids="905684977,487838322"
         )
         self.assertTrue(
             all(
-                item.location_id in params['location_ids'] and item.inventory_item_id in params['inventory_item_ids']
+                item.location_id in params["location_ids"] and item.inventory_item_id in params["inventory_item_ids"]
                 for item in inventory_levels
             )
         )
 
     def test_inventory_level_adjust(self):
         self.fake(
-            'inventory_levels/adjust',
-            method='POST',
-            body=self.load_fixture('inventory_level'),
-            headers={'Content-type': 'application/json'},
+            "inventory_levels/adjust",
+            method="POST",
+            body=self.load_fixture("inventory_level"),
+            headers={"Content-type": "application/json"},
         )
         inventory_level = shopify.InventoryLevel.adjust(905684977, 808950810, 5)
         self.assertEqual(inventory_level.available, 6)
 
     def test_inventory_level_connect(self):
         self.fake(
-            'inventory_levels/connect',
-            method='POST',
-            body=self.load_fixture('inventory_level'),
-            headers={'Content-type': 'application/json'},
+            "inventory_levels/connect",
+            method="POST",
+            body=self.load_fixture("inventory_level"),
+            headers={"Content-type": "application/json"},
             code=201,
         )
         inventory_level = shopify.InventoryLevel.connect(905684977, 808950810)
@@ -47,22 +47,22 @@ class InventoryLevelTest(TestCase):
 
     def test_inventory_level_set(self):
         self.fake(
-            'inventory_levels/set',
-            method='POST',
-            body=self.load_fixture('inventory_level'),
-            headers={'Content-type': 'application/json'},
+            "inventory_levels/set",
+            method="POST",
+            body=self.load_fixture("inventory_level"),
+            headers={"Content-type": "application/json"},
         )
         inventory_level = shopify.InventoryLevel.set(905684977, 808950810, 6)
         self.assertEqual(inventory_level.available, 6)
 
     def test_destroy_inventory_level(self):
-        inventory_level_response = json.loads(self.load_fixture('inventory_level').decode())
-        inventory_level = shopify.InventoryLevel(inventory_level_response['inventory_level'])
+        inventory_level_response = json.loads(self.load_fixture("inventory_level").decode())
+        inventory_level = shopify.InventoryLevel(inventory_level_response["inventory_level"])
 
         query_params = urlencode(
-            {'inventory_item_id': inventory_level.inventory_item_id, 'location_id': inventory_level.location_id}
+            {"inventory_item_id": inventory_level.inventory_item_id, "location_id": inventory_level.location_id}
         )
         path = "inventory_levels.json?" + query_params
 
-        self.fake(path, extension=False, method='DELETE', code=204, body='{}')
+        self.fake(path, extension=False, method="DELETE", code=204, body="{}")
         inventory_level.destroy()

--- a/test/limits_test.py
+++ b/test/limits_test.py
@@ -16,7 +16,7 @@ class LimitsTest(TestCase):
 
     def setUp(self):
         super(LimitsTest, self).setUp()
-        self.fake('shop')
+        self.fake("shop")
         shopify.Shop.current()
         # TODO: Fake not support Headers
         self.original_headers = shopify.Shop.connection.response.headers
@@ -30,36 +30,36 @@ class LimitsTest(TestCase):
             shopify.Limits.credit_left()
 
     def test_raise_error_invalid_header(self):
-        with patch.dict(shopify.Shop.connection.response.headers, {'bad': 'value'}, clear=True):
+        with patch.dict(shopify.Shop.connection.response.headers, {"bad": "value"}, clear=True):
             with self.assertRaises(Exception):
                 shopify.Limits.credit_left()
 
     def test_fetch_limits_total(self):
         with patch.dict(
-            shopify.Shop.connection.response.headers, {'X-Shopify-Shop-Api-Call-Limit': '40/40'}, clear=True
+            shopify.Shop.connection.response.headers, {"X-Shopify-Shop-Api-Call-Limit": "40/40"}, clear=True
         ):
             self.assertEqual(40, shopify.Limits.credit_limit())
 
     def test_fetch_used_calls(self):
         with patch.dict(
-            shopify.Shop.connection.response.headers, {'X-Shopify-Shop-Api-Call-Limit': '1/40'}, clear=True
+            shopify.Shop.connection.response.headers, {"X-Shopify-Shop-Api-Call-Limit": "1/40"}, clear=True
         ):
             self.assertEqual(1, shopify.Limits.credit_used())
 
     def test_calculate_remaining_calls(self):
         with patch.dict(
-            shopify.Shop.connection.response.headers, {'X-Shopify-Shop-Api-Call-Limit': '292/300'}, clear=True
+            shopify.Shop.connection.response.headers, {"X-Shopify-Shop-Api-Call-Limit": "292/300"}, clear=True
         ):
             self.assertEqual(8, shopify.Limits.credit_left())
 
     def test_maxed_credits_false(self):
         with patch.dict(
-            shopify.Shop.connection.response.headers, {'X-Shopify-Shop-Api-Call-Limit': '125/300'}, clear=True
+            shopify.Shop.connection.response.headers, {"X-Shopify-Shop-Api-Call-Limit": "125/300"}, clear=True
         ):
             self.assertFalse(shopify.Limits.credit_maxed())
 
     def test_maxed_credits_true(self):
         with patch.dict(
-            shopify.Shop.connection.response.headers, {'X-Shopify-Shop-Api-Call-Limit': '40/40'}, clear=True
+            shopify.Shop.connection.response.headers, {"X-Shopify-Shop-Api-Call-Limit": "40/40"}, clear=True
         ):
             self.assertTrue(shopify.Limits.credit_maxed())

--- a/test/location_test.py
+++ b/test/location_test.py
@@ -5,24 +5,24 @@ from test.test_helper import TestCase
 
 class LocationTest(TestCase):
     def test_fetch_locations(self):
-        self.fake("locations", method='GET', body=self.load_fixture('locations'))
+        self.fake("locations", method="GET", body=self.load_fixture("locations"))
         locations = shopify.Location.find()
         self.assertEqual(2, len(locations))
 
     def test_fetch_location(self):
-        self.fake("locations/487838322", method='GET', body=self.load_fixture('location'))
+        self.fake("locations/487838322", method="GET", body=self.load_fixture("location"))
         location = shopify.Location.find(487838322)
         self.assertEqual(location.id, 487838322)
         self.assertEqual(location.name, "Fifth Avenue AppleStore")
 
     def test_inventory_levels_returns_all_inventory_levels(self):
-        location = shopify.Location({'id': 487838322})
+        location = shopify.Location({"id": 487838322})
 
         self.fake(
             "locations/%s/inventory_levels" % location.id,
-            method='GET',
+            method="GET",
             code=200,
-            body=self.load_fixture('location_inventory_levels'),
+            body=self.load_fixture("location_inventory_levels"),
         )
         inventory_levels = location.inventory_levels()
 

--- a/test/marketing_event_test.py
+++ b/test/marketing_event_test.py
@@ -8,93 +8,93 @@ class MarketingEventTest(TestCase):
         super(MarketingEventTest, self).setUp()
 
     def test_get_marketing_event(self):
-        self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
+        self.fake("marketing_events/1", method="GET", body=self.load_fixture("marketing_event"))
         marketing_event = shopify.MarketingEvent.find(1)
         self.assertEqual(marketing_event.id, 1)
 
     def test_get_marketing_events(self):
-        self.fake('marketing_events', method='GET', body=self.load_fixture('marketing_events'))
+        self.fake("marketing_events", method="GET", body=self.load_fixture("marketing_events"))
         marketing_events = shopify.MarketingEvent.find()
         self.assertEqual(len(marketing_events), 2)
 
     def test_create_marketing_event(self):
         self.fake(
-            'marketing_events',
-            method='POST',
-            body=self.load_fixture('marketing_event'),
-            headers={'Content-type': 'application/json'},
+            "marketing_events",
+            method="POST",
+            body=self.load_fixture("marketing_event"),
+            headers={"Content-type": "application/json"},
         )
 
         marketing_event = shopify.MarketingEvent()
-        marketing_event.currency_code = 'GBP'
-        marketing_event.event_target = 'facebook'
-        marketing_event.event_type = 'post'
+        marketing_event.currency_code = "GBP"
+        marketing_event.event_target = "facebook"
+        marketing_event.event_type = "post"
         marketing_event.save()
 
-        self.assertEqual(marketing_event.event_target, 'facebook')
-        self.assertEqual(marketing_event.currency_code, 'GBP')
-        self.assertEqual(marketing_event.event_type, 'post')
+        self.assertEqual(marketing_event.event_target, "facebook")
+        self.assertEqual(marketing_event.currency_code, "GBP")
+        self.assertEqual(marketing_event.event_type, "post")
 
     def test_delete_marketing_event(self):
-        self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
-        self.fake('marketing_events/1', method='DELETE', body='destroyed')
+        self.fake("marketing_events/1", method="GET", body=self.load_fixture("marketing_event"))
+        self.fake("marketing_events/1", method="DELETE", body="destroyed")
 
         marketing_event = shopify.MarketingEvent.find(1)
         marketing_event.destroy()
 
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())
 
     def test_update_marketing_event(self):
-        self.fake('marketing_events/1', method='GET', code=200, body=self.load_fixture('marketing_event'))
+        self.fake("marketing_events/1", method="GET", code=200, body=self.load_fixture("marketing_event"))
         self.fake(
-            'marketing_events/1',
-            method='PUT',
+            "marketing_events/1",
+            method="PUT",
             code=200,
-            body=self.load_fixture('marketing_event'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("marketing_event"),
+            headers={"Content-type": "application/json"},
         )
 
         marketing_event = shopify.MarketingEvent.find(1)
-        marketing_event.currency = 'USD'
+        marketing_event.currency = "USD"
 
         self.assertTrue(marketing_event.save())
 
     def test_count_marketing_events(self):
-        self.fake('marketing_events/count', method='GET', body='{"count": 2}')
+        self.fake("marketing_events/count", method="GET", body='{"count": 2}')
         marketing_events_count = shopify.MarketingEvent.count()
         self.assertEqual(marketing_events_count, 2)
 
     def test_add_engagements(self):
-        self.fake('marketing_events/1', method='GET', body=self.load_fixture('marketing_event'))
+        self.fake("marketing_events/1", method="GET", body=self.load_fixture("marketing_event"))
         self.fake(
-            'marketing_events/1/engagements',
-            method='POST',
+            "marketing_events/1/engagements",
+            method="POST",
             code=201,
-            body=self.load_fixture('engagement'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("engagement"),
+            headers={"Content-type": "application/json"},
         )
 
         marketing_event = shopify.MarketingEvent.find(1)
         response = marketing_event.add_engagements(
             [
                 {
-                    'occurred_on': '2017-04-20',
-                    'impressions_count': None,
-                    'views_count': None,
-                    'clicks_count': 10,
-                    'shares_count': None,
-                    'favorites_count': None,
-                    'comments_count': None,
-                    'ad_spend': None,
-                    'is_cumulative': True,
+                    "occurred_on": "2017-04-20",
+                    "impressions_count": None,
+                    "views_count": None,
+                    "clicks_count": 10,
+                    "shares_count": None,
+                    "favorites_count": None,
+                    "comments_count": None,
+                    "ad_spend": None,
+                    "is_cumulative": True,
                 }
             ]
         )
 
-        request_data = json.loads(self.http.request.data.decode("utf-8"))['engagements']
+        request_data = json.loads(self.http.request.data.decode("utf-8"))["engagements"]
         self.assertEqual(len(request_data), 1)
-        self.assertEqual(request_data[0]['occurred_on'], '2017-04-20')
+        self.assertEqual(request_data[0]["occurred_on"], "2017-04-20")
 
-        response_data = json.loads(response.body.decode("utf-8"))['engagements']
+        response_data = json.loads(response.body.decode("utf-8"))["engagements"]
         self.assertEqual(len(response_data), 1)
-        self.assertEqual(response_data[0]['occurred_on'], '2017-04-20')
+        self.assertEqual(response_data[0]["occurred_on"], "2017-04-20")

--- a/test/order_risk_test.py
+++ b/test/order_risk_test.py
@@ -6,11 +6,11 @@ class OrderRiskTest(TestCase):
     def test_create_order_risk(self):
         self.fake(
             "orders/450789469/risks",
-            method='POST',
-            body=self.load_fixture('order_risk'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("order_risk"),
+            headers={"Content-type": "application/json"},
         )
-        v = shopify.OrderRisk({'order_id': 450789469})
+        v = shopify.OrderRisk({"order_id": 450789469})
         v.message = "This order was placed from a proxy IP"
         v.recommendation = "cancel"
         v.score = "1.0"
@@ -23,28 +23,28 @@ class OrderRiskTest(TestCase):
         self.assertEqual(284138680, v.id)
 
     def test_get_order_risks(self):
-        self.fake("orders/450789469/risks", method='GET', body=self.load_fixture('order_risks'))
+        self.fake("orders/450789469/risks", method="GET", body=self.load_fixture("order_risks"))
         v = shopify.OrderRisk.find(order_id=450789469)
         self.assertEqual(2, len(v))
 
     def test_get_order_risk(self):
-        self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
+        self.fake("orders/450789469/risks/284138680", method="GET", body=self.load_fixture("order_risk"))
         v = shopify.OrderRisk.find(284138680, order_id=450789469)
         self.assertEqual(284138680, v.id)
 
     def test_delete_order_risk(self):
-        self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
-        self.fake("orders/450789469/risks/284138680", method='DELETE', body="destroyed")
+        self.fake("orders/450789469/risks/284138680", method="GET", body=self.load_fixture("order_risk"))
+        self.fake("orders/450789469/risks/284138680", method="DELETE", body="destroyed")
         v = shopify.OrderRisk.find(284138680, order_id=450789469)
         v.destroy()
 
     def test_delete_order_risk(self):
-        self.fake("orders/450789469/risks/284138680", method='GET', body=self.load_fixture('order_risk'))
+        self.fake("orders/450789469/risks/284138680", method="GET", body=self.load_fixture("order_risk"))
         self.fake(
             "orders/450789469/risks/284138680",
-            method='PUT',
-            body=self.load_fixture('order_risk'),
-            headers={'Content-type': 'application/json'},
+            method="PUT",
+            body=self.load_fixture("order_risk"),
+            headers={"Content-type": "application/json"},
         )
 
         v = shopify.OrderRisk.find(284138680, order_id=450789469)

--- a/test/order_test.py
+++ b/test/order_test.py
@@ -26,7 +26,7 @@ class OrderTest(TestCase):
     def test_should_be_able_to_add_note_attributes_to_an_order(self):
         order = shopify.Order()
         order.note_attributes = []
-        order.note_attributes.append(shopify.NoteAttribute({'name': "color", 'value': "blue"}))
+        order.note_attributes.append(shopify.NoteAttribute({"name": "color", "value": "blue"}))
 
         order_xml = xml_to_dict(order.to_xml())
         note_attributes = order_xml["order"]["note_attributes"]
@@ -37,19 +37,19 @@ class OrderTest(TestCase):
         self.assertEqual("blue", attribute["value"])
 
     def test_get_order(self):
-        self.fake('orders/450789469', method='GET', body=self.load_fixture('order'))
+        self.fake("orders/450789469", method="GET", body=self.load_fixture("order"))
         order = shopify.Order.find(450789469)
-        self.assertEqual('bob.norman@hostmail.com', order.email)
+        self.assertEqual("bob.norman@hostmail.com", order.email)
 
     def test_get_order_transaction(self):
-        self.fake('orders/450789469', method='GET', body=self.load_fixture('order'))
+        self.fake("orders/450789469", method="GET", body=self.load_fixture("order"))
         order = shopify.Order.find(450789469)
-        self.fake('orders/450789469/transactions', method='GET', body=self.load_fixture('transactions'))
+        self.fake("orders/450789469/transactions", method="GET", body=self.load_fixture("transactions"))
         transactions = order.transactions()
         self.assertEqual("409.94", transactions[0].amount)
 
     def test_get_customer_orders(self):
-        self.fake("customers/207119551/orders", method='GET', body=self.load_fixture('orders'), code=200)
+        self.fake("customers/207119551/orders", method="GET", body=self.load_fixture("orders"), code=200)
         orders = shopify.Order.find(customer_id=207119551)
         self.assertIsInstance(orders[0], shopify.Order)
         self.assertEqual(450789469, orders[0].id)

--- a/test/pagination_test.py
+++ b/test/pagination_test.py
@@ -7,13 +7,13 @@ class PaginationTest(TestCase):
     def setUp(self):
         super(PaginationTest, self).setUp()
         prefix = self.http.site + "/admin/api/unstable"
-        fixture = json.loads(self.load_fixture('products').decode())
+        fixture = json.loads(self.load_fixture("products").decode())
 
         self.next_page_url = prefix + "/products.json?limit=2&page_info=FOOBAR"
         self.prev_page_url = prefix + "/products.json?limit=2&page_info=BAZQUUX"
 
-        next_headers = {"Link": "<" + self.next_page_url + ">; rel=\"next\""}
-        prev_headers = {"Link": "<" + self.prev_page_url + ">; rel=\"previous\""}
+        next_headers = {"Link": "<" + self.next_page_url + '>; rel="next"'}
+        prev_headers = {"Link": "<" + self.prev_page_url + '>; rel="previous"'}
 
         self.fake(
             "products",
@@ -35,7 +35,7 @@ class PaginationTest(TestCase):
         )
 
     def test_nonpaginates_collection(self):
-        self.fake('draft_orders', method='GET', code=200, body=self.load_fixture('draft_orders'))
+        self.fake("draft_orders", method="GET", code=200, body=self.load_fixture("draft_orders"))
         draft_orders = shopify.DraftOrder.find()
         self.assertEqual(1, len(draft_orders))
         self.assertEqual(517119332, draft_orders[0].id)

--- a/test/payouts_test.py
+++ b/test/payouts_test.py
@@ -3,15 +3,15 @@ from test.test_helper import TestCase
 
 
 class PayoutsTest(TestCase):
-    prefix = '/admin/api/unstable/shopify_payments'
+    prefix = "/admin/api/unstable/shopify_payments"
 
     def test_get_payouts(self):
-        self.fake('payouts', method='GET', prefix=self.prefix, body=self.load_fixture('payouts'))
+        self.fake("payouts", method="GET", prefix=self.prefix, body=self.load_fixture("payouts"))
         payouts = shopify.Payouts.find()
         self.assertGreater(len(payouts), 0)
 
     def test_get_one_payout(self):
-        self.fake('payouts/623721858', method='GET', prefix=self.prefix, body=self.load_fixture('payout'))
+        self.fake("payouts/623721858", method="GET", prefix=self.prefix, body=self.load_fixture("payout"))
         payouts = shopify.Payouts.find(623721858)
-        self.assertEqual('paid', payouts.status)
-        self.assertEqual('41.90', payouts.amount)
+        self.assertEqual("paid", payouts.status)
+        self.assertEqual("41.90", payouts.amount)

--- a/test/price_rules_test.py
+++ b/test/price_rules_test.py
@@ -7,43 +7,43 @@ import shopify
 class PriceRuleTest(TestCase):
     def setUp(self):
         super(PriceRuleTest, self).setUp()
-        self.fake('price_rules/1213131', body=self.load_fixture('price_rule'))
+        self.fake("price_rules/1213131", body=self.load_fixture("price_rule"))
         self.price_rule = shopify.PriceRule.find(1213131)
 
     def test_get_price_rule(self):
-        self.fake('price_rule/1213131', method='GET', code=200, body=self.load_fixture('price_rule'))
+        self.fake("price_rule/1213131", method="GET", code=200, body=self.load_fixture("price_rule"))
         price_rule = shopify.PriceRule.find(1213131)
         self.assertEqual(1213131, price_rule.id)
 
     def test_get_all_price_rules(self):
-        self.fake('price_rules', method='GET', code=200, body=self.load_fixture('price_rules'))
+        self.fake("price_rules", method="GET", code=200, body=self.load_fixture("price_rules"))
         price_rules = shopify.PriceRule.find()
         self.assertEqual(2, len(price_rules))
 
     def test_update_price_rule(self):
         self.price_rule.title = "Buy One Get One"
         self.fake(
-            'price_rules/1213131',
-            method='PUT',
+            "price_rules/1213131",
+            method="PUT",
             code=200,
-            body=self.load_fixture('price_rule'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("price_rule"),
+            headers={"Content-type": "application/json"},
         )
         self.price_rule.save()
-        self.assertEqual('Buy One Get One', json.loads(self.http.request.data.decode("utf-8"))['price_rule']['title'])
+        self.assertEqual("Buy One Get One", json.loads(self.http.request.data.decode("utf-8"))["price_rule"]["title"])
 
     def test_delete_price_rule(self):
-        self.fake('price_rules/1213131', method='DELETE', body='destroyed')
+        self.fake("price_rules/1213131", method="DELETE", body="destroyed")
         self.price_rule.destroy()
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())
 
     def test_price_rule_creation(self):
         self.fake(
-            'price_rules',
-            method='POST',
+            "price_rules",
+            method="POST",
             code=202,
-            body=self.load_fixture('price_rule'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("price_rule"),
+            headers={"Content-type": "application/json"},
         )
         price_rule = shopify.PriceRule.create(
             {
@@ -53,8 +53,8 @@ class PriceRuleTest(TestCase):
                 "allocation_method": "across",
                 "value_type": "percentage",
                 "value": -100,
-                "once_per_customer": 'true',
-                "customer_selection": 'all',
+                "once_per_customer": "true",
+                "customer_selection": "all",
             }
         )
         self.assertEqual("BOGO", price_rule.title)
@@ -62,48 +62,48 @@ class PriceRuleTest(TestCase):
 
     def test_get_discount_codes(self):
         self.fake(
-            'price_rules/1213131/discount_codes', method='GET', code=200, body=self.load_fixture('discount_codes')
+            "price_rules/1213131/discount_codes", method="GET", code=200, body=self.load_fixture("discount_codes")
         )
         discount_codes = self.price_rule.discount_codes()
         self.assertEqual(1, len(discount_codes))
 
     def test_add_discount_code(self):
-        price_rule_discount_fixture = self.load_fixture('discount_code')
+        price_rule_discount_fixture = self.load_fixture("discount_code")
         discount_code = json.loads(price_rule_discount_fixture.decode("utf-8"))
         self.fake(
-            'price_rules/1213131/discount_codes',
-            method='POST',
+            "price_rules/1213131/discount_codes",
+            method="POST",
             body=price_rule_discount_fixture,
-            headers={'Content-type': 'application/json'},
+            headers={"Content-type": "application/json"},
         )
         price_rule_discount_response = self.price_rule.add_discount_code(
-            shopify.DiscountCode(discount_code['discount_code'])
+            shopify.DiscountCode(discount_code["discount_code"])
         )
         self.assertEqual(discount_code, json.loads(self.http.request.data.decode("utf-8")))
         self.assertIsInstance(price_rule_discount_response, shopify.DiscountCode)
-        self.assertEqual(discount_code['discount_code']['code'], price_rule_discount_response.code)
+        self.assertEqual(discount_code["discount_code"]["code"], price_rule_discount_response.code)
 
     def test_create_batch_discount_codes(self):
         self.fake(
-            'price_rules/1213131/batch',
-            method='POST',
+            "price_rules/1213131/batch",
+            method="POST",
             code=201,
-            body=self.load_fixture('discount_code_creation'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("discount_code_creation"),
+            headers={"Content-type": "application/json"},
         )
-        batch = self.price_rule.create_batch([{'code': 'SUMMER1'}, {'code': 'SUMMER2'}, {'code': 'SUMMER3'}])
+        batch = self.price_rule.create_batch([{"code": "SUMMER1"}, {"code": "SUMMER2"}, {"code": "SUMMER3"}])
 
         self.assertEqual(3, batch.codes_count)
-        self.assertEqual('queued', batch.status)
+        self.assertEqual("queued", batch.status)
 
     def test_find_batch_job(self):
         self.fake(
-            'price_rules/1213131/batch/989355119',
-            method='GET',
+            "price_rules/1213131/batch/989355119",
+            method="GET",
             code=200,
-            body=self.load_fixture('discount_code_creation'),
+            body=self.load_fixture("discount_code_creation"),
         )
         batch = self.price_rule.find_batch(989355119)
 
         self.assertEqual(3, batch.codes_count)
-        self.assertEqual('queued', batch.status)
+        self.assertEqual("queued", batch.status)

--- a/test/product_listing_test.py
+++ b/test/product_listing_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class ProductListingTest(TestCase):
     def test_get_product_listings(self):
-        self.fake('product_listings', method='GET', code=200, body=self.load_fixture('product_listings'))
+        self.fake("product_listings", method="GET", code=200, body=self.load_fixture("product_listings"))
 
         product_listings = shopify.ProductListing.find()
         self.assertEqual(2, len(product_listings))
@@ -14,13 +14,13 @@ class ProductListingTest(TestCase):
         self.assertEqual("Rustic Copper Bottle", product_listings[1].title)
 
     def test_get_product_listing(self):
-        self.fake('product_listings/2', method='GET', code=200, body=self.load_fixture('product_listing'))
+        self.fake("product_listings/2", method="GET", code=200, body=self.load_fixture("product_listing"))
 
         product_listing = shopify.ProductListing.find(2)
         self.assertEqual("Synergistic Silk Chair", product_listing.title)
 
     def test_reload_product_listing(self):
-        self.fake('product_listings/2', method='GET', code=200, body=self.load_fixture('product_listing'))
+        self.fake("product_listings/2", method="GET", code=200, body=self.load_fixture("product_listing"))
 
         product_listing = shopify.ProductListing()
         product_listing.product_id = 2
@@ -30,10 +30,10 @@ class ProductListingTest(TestCase):
 
     def test_get_product_listing_product_ids(self):
         self.fake(
-            'product_listings/product_ids',
-            method='GET',
+            "product_listings/product_ids",
+            method="GET",
             status=200,
-            body=self.load_fixture('product_listing_product_ids'),
+            body=self.load_fixture("product_listing_product_ids"),
         )
 
         product_ids = shopify.ProductListing.product_ids()

--- a/test/product_publication_test.py
+++ b/test/product_publication_test.py
@@ -6,7 +6,7 @@ from test.test_helper import TestCase
 class ProductPublicationTest(TestCase):
     def test_find_all_product_publications(self):
         self.fake(
-            'publications/55650051/product_publications', method='GET', body=self.load_fixture('product_publications')
+            "publications/55650051/product_publications", method="GET", body=self.load_fixture("product_publications")
         )
         product_publications = shopify.ProductPublication.find(publication_id=55650051)
 
@@ -15,9 +15,9 @@ class ProductPublicationTest(TestCase):
 
     def test_find_product_publication(self):
         self.fake(
-            'publications/55650051/product_publications/647162527768',
-            method='GET',
-            body=self.load_fixture('product_publication'),
+            "publications/55650051/product_publications/647162527768",
+            method="GET",
+            body=self.load_fixture("product_publication"),
             code=200,
         )
         product_publication = shopify.ProductPublication.find(647162527768, publication_id=55650051)
@@ -27,27 +27,27 @@ class ProductPublicationTest(TestCase):
 
     def test_create_product_publication(self):
         self.fake(
-            'publications/55650051/product_publications',
-            method='POST',
-            headers={'Content-type': 'application/json'},
-            body=self.load_fixture('product_publication'),
+            "publications/55650051/product_publications",
+            method="POST",
+            headers={"Content-type": "application/json"},
+            body=self.load_fixture("product_publication"),
             code=201,
         )
 
         product_publication = shopify.ProductPublication.create(
             {
-                'publication_id': 55650051,
-                'published_at': "2018-01-29T14:06:08-05:00",
-                'published': True,
-                'product_id': 8267093571,
+                "publication_id": 55650051,
+                "published_at": "2018-01-29T14:06:08-05:00",
+                "published": True,
+                "product_id": 8267093571,
             }
         )
 
         expected_body = {
-            'product_publication': {
-                'published_at': "2018-01-29T14:06:08-05:00",
-                'published': True,
-                'product_id': 8267093571,
+            "product_publication": {
+                "published_at": "2018-01-29T14:06:08-05:00",
+                "published": True,
+                "product_id": 8267093571,
             }
         }
 
@@ -55,14 +55,14 @@ class ProductPublicationTest(TestCase):
 
     def test_destroy_product_publication(self):
         self.fake(
-            'publications/55650051/product_publications/647162527768',
-            method='GET',
-            body=self.load_fixture('product_publication'),
+            "publications/55650051/product_publications/647162527768",
+            method="GET",
+            body=self.load_fixture("product_publication"),
             code=200,
         )
         product_publication = shopify.ProductPublication.find(647162527768, publication_id=55650051)
 
-        self.fake('publications/55650051/product_publications/647162527768', method='DELETE', body='{}', code=200)
+        self.fake("publications/55650051/product_publications/647162527768", method="DELETE", body="{}", code=200)
         product_publication.destroy()
 
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())

--- a/test/product_test.py
+++ b/test/product_test.py
@@ -6,21 +6,21 @@ class ProductTest(TestCase):
     def setUp(self):
         super(ProductTest, self).setUp()
 
-        self.fake("products/632910392", body=self.load_fixture('product'))
+        self.fake("products/632910392", body=self.load_fixture("product"))
         self.product = shopify.Product.find(632910392)
 
     def test_add_metafields_to_product(self):
         self.fake(
             "products/632910392/metafields",
-            method='POST',
+            method="POST",
             code=201,
-            body=self.load_fixture('metafield'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("metafield"),
+            headers={"Content-type": "application/json"},
         )
 
         field = self.product.add_metafield(
             shopify.Metafield(
-                {'namespace': "contact", 'key': "email", 'value': "123@example.com", 'value_type': "string"}
+                {"namespace": "contact", "key": "email", "value": "123@example.com", "value_type": "string"}
             )
         )
 
@@ -30,7 +30,7 @@ class ProductTest(TestCase):
         self.assertEqual("123@example.com", field.value)
 
     def test_get_metafields_for_product(self):
-        self.fake("products/632910392/metafields", body=self.load_fixture('metafields'))
+        self.fake("products/632910392/metafields", body=self.load_fixture("metafields"))
 
         metafields = self.product.metafields()
 
@@ -39,7 +39,7 @@ class ProductTest(TestCase):
             self.assertTrue(isinstance(field, shopify.Metafield))
 
     def test_get_metafields_for_product_with_params(self):
-        self.fake("products/632910392/metafields.json?limit=2", extension=False, body=self.load_fixture('metafields'))
+        self.fake("products/632910392/metafields.json?limit=2", extension=False, body=self.load_fixture("metafields"))
 
         metafields = self.product.metafields(limit=2)
         self.assertEqual(2, len(metafields))
@@ -47,7 +47,7 @@ class ProductTest(TestCase):
             self.assertTrue(isinstance(field, shopify.Metafield))
 
     def test_get_metafields_for_product_count(self):
-        self.fake("products/632910392/metafields/count", body=self.load_fixture('metafields_count'))
+        self.fake("products/632910392/metafields/count", body=self.load_fixture("metafields_count"))
 
         metafields_count = self.product.metafields_count()
         self.assertEqual(2, metafields_count)
@@ -56,14 +56,14 @@ class ProductTest(TestCase):
         self.fake(
             "products/632910392/metafields/count.json?value_type=string",
             extension=False,
-            body=self.load_fixture('metafields_count'),
+            body=self.load_fixture("metafields_count"),
         )
 
         metafields_count = self.product.metafields_count(value_type="string")
         self.assertEqual(2, metafields_count)
 
     def test_update_loaded_variant(self):
-        self.fake("products/632910392/variants/808950810", method='PUT', code=200, body=self.load_fixture('variant'))
+        self.fake("products/632910392/variants/808950810", method="PUT", code=200, body=self.load_fixture("variant"))
 
         variant = self.product.variants[0]
         variant.price = "0.50"
@@ -72,16 +72,16 @@ class ProductTest(TestCase):
     def test_add_variant_to_product(self):
         self.fake(
             "products/632910392/variants",
-            method='POST',
-            body=self.load_fixture('variant'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("variant"),
+            headers={"Content-type": "application/json"},
         )
         self.fake(
             "products/632910392/variants/808950810",
-            method='PUT',
+            method="PUT",
             code=200,
-            body=self.load_fixture('variant'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("variant"),
+            headers={"Content-type": "application/json"},
         )
         v = shopify.Variant()
         self.assertTrue(self.product.add_variant(v))

--- a/test/publication_test.py
+++ b/test/publication_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class PublicationTest(TestCase):
     def test_find_all_publications(self):
-        self.fake('publications')
+        self.fake("publications")
         publications = shopify.Publication.find()
 
         self.assertEqual(55650051, publications[0].id)

--- a/test/recurring_charge_test.py
+++ b/test/recurring_charge_test.py
@@ -7,11 +7,11 @@ class RecurringApplicationChargeTest(TestCase):
         # Just check that calling activate doesn't raise an exception.
         self.fake(
             "recurring_application_charges/35463/activate",
-            method='POST',
-            headers={'Content-length': '0', 'Content-type': 'application/json'},
+            method="POST",
+            headers={"Content-length": "0", "Content-type": "application/json"},
             body=" ",
         )
-        charge = shopify.RecurringApplicationCharge({'id': 35463})
+        charge = shopify.RecurringApplicationCharge({"id": 35463})
         charge.activate()
 
     def test_current_method_returns_active_charge(self):
@@ -34,8 +34,8 @@ class RecurringApplicationChargeTest(TestCase):
 
         self.fake(
             "recurring_application_charges/455696195/usage_charges",
-            method='GET',
-            body=self.load_fixture('usage_charges'),
+            method="GET",
+            body=self.load_fixture("usage_charges"),
         )
         usage_charges = charge.usage_charges()
         self.assertEqual(len(usage_charges), 2)
@@ -48,16 +48,16 @@ class RecurringApplicationChargeTest(TestCase):
         self.fake(
             "recurring_application_charges/455696195/customize.json?recurring_application_charge%5Bcapped_amount%5D=200",
             extension=False,
-            method='PUT',
-            headers={'Content-length': '0', 'Content-type': 'application/json'},
-            body=self.load_fixture('recurring_application_charge_adjustment'),
+            method="PUT",
+            headers={"Content-length": "0", "Content-type": "application/json"},
+            body=self.load_fixture("recurring_application_charge_adjustment"),
         )
         charge.customize(capped_amount=200)
         self.assertTrue(charge.update_capped_amount_url)
 
     def test_destroy_recurring_application_charge(self):
-        self.fake('recurring_application_charges')
+        self.fake("recurring_application_charges")
         charge = shopify.RecurringApplicationCharge.current()
 
-        self.fake('recurring_application_charges/455696195', method='DELETE', body='{}')
+        self.fake("recurring_application_charges/455696195", method="DELETE", body="{}")
         charge.destroy()

--- a/test/refund_test.py
+++ b/test/refund_test.py
@@ -5,7 +5,7 @@ from test.test_helper import TestCase
 class RefundTest(TestCase):
     def setUp(self):
         super(RefundTest, self).setUp()
-        self.fake("orders/450789469/refunds/509562969", method='GET', body=self.load_fixture('refund'))
+        self.fake("orders/450789469/refunds/509562969", method="GET", body=self.load_fixture("refund"))
 
     def test_should_find_a_specific_refund(self):
         refund = shopify.Refund.find(509562969, order_id=450789469)
@@ -16,11 +16,11 @@ class RefundTest(TestCase):
             "orders/450789469/refunds/calculate",
             method="POST",
             code=201,
-            body=self.load_fixture('refund_calculate'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("refund_calculate"),
+            headers={"Content-type": "application/json"},
         )
         refund = shopify.Refund.calculate(
-            order_id=450789469, refund_line_items=[{'line_item_id': 518995019, 'quantity': 1}]
+            order_id=450789469, refund_line_items=[{"line_item_id": 518995019, "quantity": 1}]
         )
 
         self.assertEqual("suggested_refund", refund.transactions[0].kind)

--- a/test/report_test.py
+++ b/test/report_test.py
@@ -4,22 +4,22 @@ from test.test_helper import TestCase
 
 class CustomerSavedSearchTest(TestCase):
     def test_get_report(self):
-        self.fake('reports/987', method='GET', code=200, body=self.load_fixture('report'))
+        self.fake("reports/987", method="GET", code=200, body=self.load_fixture("report"))
         report = shopify.Report.find(987)
         self.assertEqual(987, report.id)
 
     def test_get_reports(self):
-        self.fake('reports', method='GET', code=200, body=self.load_fixture('reports'))
+        self.fake("reports", method="GET", code=200, body=self.load_fixture("reports"))
         reports = shopify.Report.find()
-        self.assertEqual('custom_app_reports', reports[0].category)
+        self.assertEqual("custom_app_reports", reports[0].category)
 
     def test_create_report(self):
         self.fake(
-            'reports',
-            method='POST',
+            "reports",
+            method="POST",
             code=201,
-            body=self.load_fixture('report'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("report"),
+            headers={"Content-type": "application/json"},
         )
         report = shopify.Report.create(
             {
@@ -27,10 +27,10 @@ class CustomerSavedSearchTest(TestCase):
                 "shopify_ql": "SHOW quantity_count, total_sales BY product_type, vendor, product_title FROM products SINCE -1m UNTIL -0m ORDER BY total_sales DESC",
             }
         )
-        self.assertEqual('custom_app_reports', report.category)
+        self.assertEqual("custom_app_reports", report.category)
 
     def test_delete_report(self):
-        self.fake('reports/987', method='GET', code=200, body=self.load_fixture('report'))
-        self.fake('reports', method='DELETE', code=200, body='[]')
+        self.fake("reports/987", method="GET", code=200, body=self.load_fixture("report"))
+        self.fake("reports", method="DELETE", code=200, body="[]")
         report = shopify.Report.find(987)
         self.assertTrue(report.destroy)

--- a/test/resource_feedback_test.py
+++ b/test/resource_feedback_test.py
@@ -5,36 +5,36 @@ from test.test_helper import TestCase
 
 class ResourceFeedbackTest(TestCase):
     def test_get_resource_feedback(self):
-        body = json.dumps({'resource_feedback': [{'resource_type': 'Shop'}]})
-        self.fake('resource_feedback', method='GET', body=body)
+        body = json.dumps({"resource_feedback": [{"resource_type": "Shop"}]})
+        self.fake("resource_feedback", method="GET", body=body)
 
         feedback = shopify.ResourceFeedback.find()
 
-        self.assertEqual('Shop', feedback[0].resource_type)
+        self.assertEqual("Shop", feedback[0].resource_type)
 
     def test_save_with_resource_feedback_endpoint(self):
-        body = json.dumps({'resource_feedback': {}})
-        self.fake('resource_feedback', method='POST', body=body, headers={'Content-Type': 'application/json'})
+        body = json.dumps({"resource_feedback": {}})
+        self.fake("resource_feedback", method="POST", body=body, headers={"Content-Type": "application/json"})
 
         shopify.ResourceFeedback().save()
 
         self.assertEqual(body, self.http.request.data.decode("utf-8"))
 
     def test_get_resource_feedback_with_product_id(self):
-        body = json.dumps({'resource_feedback': [{'resource_type': 'Product'}]})
-        self.fake('products/42/resource_feedback', method='GET', body=body)
+        body = json.dumps({"resource_feedback": [{"resource_type": "Product"}]})
+        self.fake("products/42/resource_feedback", method="GET", body=body)
 
         feedback = shopify.ResourceFeedback.find(product_id=42)
 
-        self.assertEqual('Product', feedback[0].resource_type)
+        self.assertEqual("Product", feedback[0].resource_type)
 
     def test_save_with_product_id_resource_feedback_endpoint(self):
-        body = json.dumps({'resource_feedback': {}})
+        body = json.dumps({"resource_feedback": {}})
         self.fake(
-            'products/42/resource_feedback', method='POST', body=body, headers={'Content-Type': 'application/json'}
+            "products/42/resource_feedback", method="POST", body=body, headers={"Content-Type": "application/json"}
         )
 
-        feedback = shopify.ResourceFeedback({'product_id': 42})
+        feedback = shopify.ResourceFeedback({"product_id": 42})
         feedback.save()
 
         self.assertEqual(body, self.http.request.data.decode("utf-8"))

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -11,36 +11,36 @@ class SessionTest(TestCase):
     @classmethod
     def setUpClass(self):
         shopify.ApiVersion.define_known_versions()
-        shopify.ApiVersion.define_version(shopify.Release('2019-04'))
+        shopify.ApiVersion.define_version(shopify.Release("2019-04"))
 
     @classmethod
     def tearDownClass(self):
         shopify.ApiVersion.clear_defined_versions()
 
     def test_not_be_valid_without_a_url(self):
-        session = shopify.Session("", 'unstable', 'any-token')
+        session = shopify.Session("", "unstable", "any-token")
         self.assertFalse(session.valid)
 
     def test_not_be_valid_without_token(self):
-        session = shopify.Session("testshop.myshopify.com", 'unstable')
+        session = shopify.Session("testshop.myshopify.com", "unstable")
         self.assertFalse(session.valid)
 
     def test_be_valid_with_any_token_and_any_url(self):
-        session = shopify.Session("testshop.myshopify.com", 'unstable', "any-token")
+        session = shopify.Session("testshop.myshopify.com", "unstable", "any-token")
         self.assertTrue(session.valid)
 
     def test_ignore_everything_but_the_subdomain_in_the_shop(self):
-        session = shopify.Session("http://user:pass@testshop.notshopify.net/path", 'unstable', "any-token")
+        session = shopify.Session("http://user:pass@testshop.notshopify.net/path", "unstable", "any-token")
         self.assertEqual("https://testshop.myshopify.com/admin/api/unstable", session.site)
 
     def test_append_the_myshopify_domain_if_not_given(self):
-        session = shopify.Session("testshop", 'unstable', "any-token")
+        session = shopify.Session("testshop", "unstable", "any-token")
         self.assertEqual("https://testshop.myshopify.com/admin/api/unstable", session.site)
 
     def test_raise_error_if_params_passed_but_signature_omitted(self):
         with self.assertRaises(shopify.ValidationException):
-            session = shopify.Session("testshop.myshopify.com", 'unstable')
-            token = session.request_token({'code': 'any_code', 'foo': 'bar', 'timestamp': '1234'})
+            session = shopify.Session("testshop.myshopify.com", "unstable")
+            token = session.request_token({"code": "any_code", "foo": "bar", "timestamp": "1234"})
 
     def test_setup_api_key_and_secret_for_all_sessions(self):
         shopify.Session.setup(api_key="My test key", secret="My test secret")
@@ -48,31 +48,31 @@ class SessionTest(TestCase):
         self.assertEqual("My test secret", shopify.Session.secret)
 
     def test_use_https_protocol_by_default_for_all_sessions(self):
-        self.assertEqual('https', shopify.Session.protocol)
+        self.assertEqual("https", shopify.Session.protocol)
 
     def test_temp_reset_shopify_ShopifyResource_site_to_original_value(self):
         shopify.Session.setup(api_key="key", secret="secret")
-        session1 = shopify.Session('fakeshop.myshopify.com', '2019-04', 'token1')
+        session1 = shopify.Session("fakeshop.myshopify.com", "2019-04", "token1")
         shopify.ShopifyResource.activate_session(session1)
 
         assigned_site = ""
-        with shopify.Session.temp("testshop.myshopify.com", 'unstable', "any-token"):
+        with shopify.Session.temp("testshop.myshopify.com", "unstable", "any-token"):
             assigned_site = shopify.ShopifyResource.site
 
-        self.assertEqual('https://testshop.myshopify.com/admin/api/unstable', assigned_site)
-        self.assertEqual('https://fakeshop.myshopify.com/admin/api/2019-04', shopify.ShopifyResource.site)
+        self.assertEqual("https://testshop.myshopify.com/admin/api/unstable", assigned_site)
+        self.assertEqual("https://fakeshop.myshopify.com/admin/api/2019-04", shopify.ShopifyResource.site)
 
     def test_myshopify_domain_supports_non_standard_ports(self):
         try:
             shopify.Session.setup(api_key="key", secret="secret", myshopify_domain="localhost", port=3000)
 
-            session = shopify.Session('fakeshop.localhost:3000', 'unstable', 'token1')
+            session = shopify.Session("fakeshop.localhost:3000", "unstable", "token1")
             shopify.ShopifyResource.activate_session(session)
-            self.assertEqual('https://fakeshop.localhost:3000/admin/api/unstable', shopify.ShopifyResource.site)
+            self.assertEqual("https://fakeshop.localhost:3000/admin/api/unstable", shopify.ShopifyResource.site)
 
-            session = shopify.Session('fakeshop', 'unstable', 'token1')
+            session = shopify.Session("fakeshop", "unstable", "token1")
             shopify.ShopifyResource.activate_session(session)
-            self.assertEqual('https://fakeshop.localhost:3000/admin/api/unstable', shopify.ShopifyResource.site)
+            self.assertEqual("https://fakeshop.localhost:3000/admin/api/unstable", shopify.ShopifyResource.site)
         finally:
             shopify.Session.setup(myshopify_domain="myshopify.com", port=None)
 
@@ -80,15 +80,15 @@ class SessionTest(TestCase):
         shopify.ShopifyResource.clear_session()
 
         assigned_site = ""
-        with shopify.Session.temp("testshop.myshopify.com", 'unstable', 'any-token'):
+        with shopify.Session.temp("testshop.myshopify.com", "unstable", "any-token"):
             assigned_site = shopify.ShopifyResource.site
 
-        self.assertEqual('https://testshop.myshopify.com/admin/api/unstable', assigned_site)
-        self.assertEqual('https://none/admin/api/unstable', shopify.ShopifyResource.site)
+        self.assertEqual("https://testshop.myshopify.com/admin/api/unstable", assigned_site)
+        self.assertEqual("https://none/admin/api/unstable", shopify.ShopifyResource.site)
 
     def test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         scope = ["write_products"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
         self.assertEqual(
@@ -98,7 +98,7 @@ class SessionTest(TestCase):
 
     def test_create_permission_url_returns_correct_url_with_dual_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         scope = ["write_products", "write_customers"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
         self.assertEqual(
@@ -108,7 +108,7 @@ class SessionTest(TestCase):
 
     def test_create_permission_url_returns_correct_url_with_no_scope_and_redirect_uri(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         scope = []
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com")
         self.assertEqual(
@@ -118,7 +118,7 @@ class SessionTest(TestCase):
 
     def test_create_permission_url_returns_correct_url_with_no_scope_and_redirect_uri_and_state(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         scope = []
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com", state="mystate")
         self.assertEqual(
@@ -128,7 +128,7 @@ class SessionTest(TestCase):
 
     def test_create_permission_url_returns_correct_url_with_single_scope_and_redirect_uri_and_state(self):
         shopify.Session.setup(api_key="My_test_key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         scope = ["write_customers"]
         permission_url = session.create_permission_url(scope, "my_redirect_uri.com", state="mystate")
         self.assertEqual(
@@ -138,123 +138,123 @@ class SessionTest(TestCase):
 
     def test_raise_exception_if_code_invalid_in_request_token(self):
         shopify.Session.setup(api_key="My test key", secret="My test secret")
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         self.fake(
             None,
-            url='https://localhost.myshopify.com/admin/oauth/access_token',
-            method='POST',
+            url="https://localhost.myshopify.com/admin/oauth/access_token",
+            method="POST",
             code=404,
             body='{"error" : "invalid_request"}',
             has_user_agent=False,
         )
 
         with self.assertRaises(shopify.ValidationException):
-            session.request_token({'code': 'any-code', 'timestamp': '1234'})
+            session.request_token({"code": "any-code", "timestamp": "1234"})
 
         self.assertFalse(session.valid)
 
     def test_return_site_for_session(self):
-        session = shopify.Session("testshop.myshopify.com", 'unstable', 'any-token')
+        session = shopify.Session("testshop.myshopify.com", "unstable", "any-token")
         self.assertEqual("https://testshop.myshopify.com/admin/api/unstable", session.site)
 
     def test_hmac_calculation(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret = 'hush'
+        shopify.Session.secret = "hush"
         params = {
-            'shop': 'some-shop.myshopify.com',
-            'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
-            'timestamp': '1337178173',
-            'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
+            "shop": "some-shop.myshopify.com",
+            "code": "a94a110d86d2452eb3e2af4cfb8a3828",
+            "timestamp": "1337178173",
+            "hmac": "2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2",
         }
-        self.assertEqual(shopify.Session.calculate_hmac(params), params['hmac'])
+        self.assertEqual(shopify.Session.calculate_hmac(params), params["hmac"])
 
     def test_hmac_calculation_with_ampersand_and_equal_sign_characters(self):
-        shopify.Session.secret = 'secret'
-        params = {'a': '1&b=2', 'c=3&d': '4'}
+        shopify.Session.secret = "secret"
+        params = {"a": "1&b=2", "c=3&d": "4"}
         to_sign = "a=1%26b=2&c%3D3%26d=4"
-        expected_hmac = hmac.new('secret'.encode(), to_sign.encode(), sha256).hexdigest()
+        expected_hmac = hmac.new("secret".encode(), to_sign.encode(), sha256).hexdigest()
         self.assertEqual(shopify.Session.calculate_hmac(params), expected_hmac)
 
     def test_hmac_validation(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret = 'hush'
+        shopify.Session.secret = "hush"
         params = {
-            'shop': 'some-shop.myshopify.com',
-            'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
-            'timestamp': '1337178173',
-            'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
+            "shop": "some-shop.myshopify.com",
+            "code": "a94a110d86d2452eb3e2af4cfb8a3828",
+            "timestamp": "1337178173",
+            "hmac": u("2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2"),
         }
         self.assertTrue(shopify.Session.validate_hmac(params))
 
     def test_parameter_validation_handles_missing_params(self):
         # Test using the secret and parameter examples given in the Shopify API documentation.
-        shopify.Session.secret = 'hush'
+        shopify.Session.secret = "hush"
         params = {
-            'shop': 'some-shop.myshopify.com',
-            'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
-            'hmac': u('2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2'),
+            "shop": "some-shop.myshopify.com",
+            "code": "a94a110d86d2452eb3e2af4cfb8a3828",
+            "hmac": u("2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2"),
         }
         self.assertFalse(shopify.Session.validate_params(params))
 
     def test_param_validation_of_param_values_with_lists(self):
-        shopify.Session.secret = 'hush'
+        shopify.Session.secret = "hush"
         params = {
-            'shop': 'some-shop.myshopify.com',
-            'ids[]': [
+            "shop": "some-shop.myshopify.com",
+            "ids[]": [
                 2,
                 1,
             ],
-            'hmac': u('b93b9f82996f6f8bf9f1b7bbddec284c8fabacdc4e12dc80550b4705f3003b1e'),
+            "hmac": u("b93b9f82996f6f8bf9f1b7bbddec284c8fabacdc4e12dc80550b4705f3003b1e"),
         }
         self.assertEqual(True, shopify.Session.validate_hmac(params))
 
     def test_return_token_if_hmac_is_valid(self):
-        shopify.Session.secret = 'secret'
-        params = {'code': 'any-code', 'timestamp': time.time()}
+        shopify.Session.secret = "secret"
+        params = {"code": "any-code", "timestamp": time.time()}
         hmac = shopify.Session.calculate_hmac(params)
-        params['hmac'] = hmac
+        params["hmac"] = hmac
 
         self.fake(
             None,
-            url='https://localhost.myshopify.com/admin/oauth/access_token',
-            method='POST',
+            url="https://localhost.myshopify.com/admin/oauth/access_token",
+            method="POST",
             body='{"access_token" : "token"}',
             has_user_agent=False,
         )
-        session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+        session = shopify.Session("http://localhost.myshopify.com", "unstable")
         token = session.request_token(params)
         self.assertEqual("token", token)
 
     def test_raise_error_if_hmac_is_invalid(self):
-        shopify.Session.secret = 'secret'
-        params = {'code': 'any-code', 'timestamp': time.time()}
-        params['hmac'] = 'a94a110d86d2452e92a4a64275b128e9273be3037f2c339eb3e2af4cfb8a3828'
+        shopify.Session.secret = "secret"
+        params = {"code": "any-code", "timestamp": time.time()}
+        params["hmac"] = "a94a110d86d2452e92a4a64275b128e9273be3037f2c339eb3e2af4cfb8a3828"
 
         with self.assertRaises(shopify.ValidationException):
-            session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+            session = shopify.Session("http://localhost.myshopify.com", "unstable")
             session = session.request_token(params)
 
     def test_raise_error_if_hmac_does_not_match_expected(self):
-        shopify.Session.secret = 'secret'
-        params = {'foo': 'hello', 'timestamp': time.time()}
+        shopify.Session.secret = "secret"
+        params = {"foo": "hello", "timestamp": time.time()}
         hmac = shopify.Session.calculate_hmac(params)
-        params['hmac'] = hmac
-        params['bar'] = 'world'
-        params['code'] = 'code'
+        params["hmac"] = hmac
+        params["bar"] = "world"
+        params["code"] = "code"
 
         with self.assertRaises(shopify.ValidationException):
-            session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+            session = shopify.Session("http://localhost.myshopify.com", "unstable")
             session = session.request_token(params)
 
     def test_raise_error_if_timestamp_is_too_old(self):
-        shopify.Session.secret = 'secret'
+        shopify.Session.secret = "secret"
         one_day = 24 * 60 * 60
-        params = {'code': 'any-code', 'timestamp': time.time() - (2 * one_day)}
+        params = {"code": "any-code", "timestamp": time.time() - (2 * one_day)}
         hmac = shopify.Session.calculate_hmac(params)
-        params['hmac'] = hmac
+        params["hmac"] = hmac
 
         with self.assertRaises(shopify.ValidationException):
-            session = shopify.Session('http://localhost.myshopify.com', 'unstable')
+            session = shopify.Session("http://localhost.myshopify.com", "unstable")
             session = session.request_token(params)
 
     def normalize_url(self, url):

--- a/test/shipping_zone_test.py
+++ b/test/shipping_zone_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class ShippingZoneTest(TestCase):
     def test_get_shipping_zones(self):
-        self.fake("shipping_zones", method='GET', body=self.load_fixture('shipping_zones'))
+        self.fake("shipping_zones", method="GET", body=self.load_fixture("shipping_zones"))
         shipping_zones = shopify.ShippingZone.find()
         self.assertEqual(1, len(shipping_zones))
         self.assertEqual(shipping_zones[0].name, "Some zone")

--- a/test/shop_test.py
+++ b/test/shop_test.py
@@ -28,15 +28,15 @@ class ShopTest(TestCase):
     def test_add_metafield(self):
         self.fake(
             "metafields",
-            method='POST',
+            method="POST",
             code=201,
-            body=self.load_fixture('metafield'),
-            headers={'Content-type': 'application/json'},
+            body=self.load_fixture("metafield"),
+            headers={"Content-type": "application/json"},
         )
 
         field = self.shop.add_metafield(
             shopify.Metafield(
-                {'namespace': "contact", 'key': "email", 'value': "123@example.com", 'value_type': "string"}
+                {"namespace": "contact", "key": "email", "value": "123@example.com", "value_type": "string"}
             )
         )
 

--- a/test/storefront_access_token_test.py
+++ b/test/storefront_access_token_test.py
@@ -5,28 +5,28 @@ from test.test_helper import TestCase
 class StorefrontAccessTokenTest(TestCase):
     def test_create_storefront_access_token(self):
         self.fake(
-            'storefront_access_tokens',
-            method='POST',
-            body=self.load_fixture('storefront_access_token'),
-            headers={'Content-type': 'application/json'},
+            "storefront_access_tokens",
+            method="POST",
+            body=self.load_fixture("storefront_access_token"),
+            headers={"Content-type": "application/json"},
         )
-        storefront_access_token = shopify.StorefrontAccessToken.create({'title': 'Test'})
+        storefront_access_token = shopify.StorefrontAccessToken.create({"title": "Test"})
         self.assertEqual(1, storefront_access_token.id)
         self.assertEqual("Test", storefront_access_token.title)
 
     def test_get_and_delete_storefront_access_token(self):
         self.fake(
-            'storefront_access_tokens/1', method='GET', code=200, body=self.load_fixture('storefront_access_token')
+            "storefront_access_tokens/1", method="GET", code=200, body=self.load_fixture("storefront_access_token")
         )
         storefront_access_token = shopify.StorefrontAccessToken.find(1)
 
-        self.fake('storefront_access_tokens/1', method='DELETE', code=200, body='destroyed')
+        self.fake("storefront_access_tokens/1", method="DELETE", code=200, body="destroyed")
         storefront_access_token.destroy()
-        self.assertEqual('DELETE', self.http.request.get_method())
+        self.assertEqual("DELETE", self.http.request.get_method())
 
     def test_get_storefront_access_tokens(self):
         self.fake(
-            'storefront_access_tokens', method='GET', code=200, body=self.load_fixture('storefront_access_tokens')
+            "storefront_access_tokens", method="GET", code=200, body=self.load_fixture("storefront_access_tokens")
         )
         tokens = shopify.StorefrontAccessToken.find()
 

--- a/test/tender_transaction_test.py
+++ b/test/tender_transaction_test.py
@@ -5,7 +5,7 @@ from test.test_helper import TestCase
 class TenderTransactionTest(TestCase):
     def setUp(self):
         super(TenderTransactionTest, self).setUp()
-        self.fake("tender_transactions", method='GET', body=self.load_fixture('tender_transactions'))
+        self.fake("tender_transactions", method="GET", body=self.load_fixture("tender_transactions"))
 
     def test_should_load_all_tender_transactions(self):
         tender_transactions = shopify.TenderTransaction.find()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -18,48 +18,48 @@ class TestCase(unittest.TestCase):
 
         http_fake.initialize()
         self.http = http_fake.TestHandler
-        self.http.set_response(Exception('Bad request'))
-        self.http.site = 'https://this-is-my-test-show.myshopify.com'
+        self.http.set_response(Exception("Bad request"))
+        self.http.site = "https://this-is-my-test-show.myshopify.com"
         self.fake(
-            'apis',
-            url='https://app.shopify.com/services/apis.json',
-            method='GET',
+            "apis",
+            url="https://app.shopify.com/services/apis.json",
+            method="GET",
             code=200,
-            response_headers={'Content-type': 'application/json'},
-            body=self.load_fixture('api_version'),
+            response_headers={"Content-type": "application/json"},
+            body=self.load_fixture("api_version"),
             has_user_agent=False,
         )
 
-    def load_fixture(self, name, format='json'):
-        with open(os.path.dirname(__file__) + '/fixtures/%s.%s' % (name, format), 'rb') as f:
+    def load_fixture(self, name, format="json"):
+        with open(os.path.dirname(__file__) + "/fixtures/%s.%s" % (name, format), "rb") as f:
             return f.read()
 
     def fake(self, endpoint, **kwargs):
-        body = kwargs.pop('body', None) or self.load_fixture(endpoint)
-        format = kwargs.pop('format', 'json')
-        method = kwargs.pop('method', 'GET')
-        prefix = kwargs.pop('prefix', '/admin/api/unstable')
+        body = kwargs.pop("body", None) or self.load_fixture(endpoint)
+        format = kwargs.pop("format", "json")
+        method = kwargs.pop("method", "GET")
+        prefix = kwargs.pop("prefix", "/admin/api/unstable")
 
-        if 'extension' in kwargs and not kwargs['extension']:
+        if "extension" in kwargs and not kwargs["extension"]:
             extension = ""
         else:
-            extension = ".%s" % (kwargs.pop('extension', 'json'))
-        if kwargs.get('url'):
-            url = kwargs.get('url')
+            extension = ".%s" % (kwargs.pop("extension", "json"))
+        if kwargs.get("url"):
+            url = kwargs.get("url")
         else:
             url = "https://this-is-my-test-show.myshopify.com%s/%s%s" % (prefix, endpoint, extension)
         headers = {}
-        if kwargs.pop('has_user_agent', True):
-            userAgent = 'ShopifyPythonAPI/%s Python/%s' % (shopify.VERSION, sys.version.split(' ', 1)[0])
-            headers['User-agent'] = userAgent
+        if kwargs.pop("has_user_agent", True):
+            userAgent = "ShopifyPythonAPI/%s Python/%s" % (shopify.VERSION, sys.version.split(" ", 1)[0])
+            headers["User-agent"] = userAgent
 
         try:
-            headers.update(kwargs['headers'])
+            headers.update(kwargs["headers"])
         except KeyError:
             pass
 
-        code = kwargs.pop('code', 200)
+        code = kwargs.pop("code", 200)
 
         self.http.respond_to(
-            method, url, headers, body=body, code=code, response_headers=kwargs.pop('response_headers', None)
+            method, url, headers, body=body, code=code, response_headers=kwargs.pop("response_headers", None)
         )

--- a/test/transaction_test.py
+++ b/test/transaction_test.py
@@ -5,7 +5,7 @@ from test.test_helper import TestCase
 class TransactionTest(TestCase):
     def setUp(self):
         super(TransactionTest, self).setUp()
-        self.fake("orders/450789469/transactions/389404469", method='GET', body=self.load_fixture('transaction'))
+        self.fake("orders/450789469/transactions/389404469", method="GET", body=self.load_fixture("transaction"))
 
     def test_should_find_a_specific_transaction(self):
         transaction = shopify.Transaction.find(389404469, order_id=450789469)

--- a/test/transactions_test.py
+++ b/test/transactions_test.py
@@ -3,9 +3,9 @@ from test.test_helper import TestCase
 
 
 class TransactionsTest(TestCase):
-    prefix = '/admin/api/unstable/shopify_payments/balance'
+    prefix = "/admin/api/unstable/shopify_payments/balance"
 
     def test_get_payouts_transactions(self):
-        self.fake('transactions', method='GET', prefix=self.prefix, body=self.load_fixture('payouts_transactions'))
+        self.fake("transactions", method="GET", prefix=self.prefix, body=self.load_fixture("payouts_transactions"))
         transactions = shopify.Transactions.find()
         self.assertGreater(len(transactions), 0)

--- a/test/usage_charge_test.py
+++ b/test/usage_charge_test.py
@@ -6,23 +6,23 @@ class UsageChargeTest(TestCase):
     def test_create_usage_charge(self):
         self.fake(
             "recurring_application_charges/654381177/usage_charges",
-            method='POST',
-            body=self.load_fixture('usage_charge'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("usage_charge"),
+            headers={"Content-type": "application/json"},
         )
 
         charge = shopify.UsageCharge(
-            {'price': 9.0, 'description': '1000 emails', 'recurring_application_charge_id': 654381177}
+            {"price": 9.0, "description": "1000 emails", "recurring_application_charge_id": 654381177}
         )
         charge.save()
-        self.assertEqual('1000 emails', charge.description)
+        self.assertEqual("1000 emails", charge.description)
 
     def test_get_usage_charge(self):
         self.fake(
             "recurring_application_charges/654381177/usage_charges/359376002",
-            method='GET',
-            body=self.load_fixture('usage_charge'),
+            method="GET",
+            body=self.load_fixture("usage_charge"),
         )
 
         charge = shopify.UsageCharge.find(359376002, recurring_application_charge_id=654381177)
-        self.assertEqual('1000 emails', charge.description)
+        self.assertEqual("1000 emails", charge.description)

--- a/test/user_test.py
+++ b/test/user_test.py
@@ -4,7 +4,7 @@ from test.test_helper import TestCase
 
 class UserTest(TestCase):
     def test_get_all_users(self):
-        self.fake('users', body=self.load_fixture('users'))
+        self.fake("users", body=self.load_fixture("users"))
         users = shopify.User.find()
 
         self.assertEqual(2, len(users))
@@ -12,14 +12,14 @@ class UserTest(TestCase):
         self.assertEqual("Jobs", users[0].last_name)
 
     def test_get_user(self):
-        self.fake('users/799407056', body=self.load_fixture('user'))
+        self.fake("users/799407056", body=self.load_fixture("user"))
         user = shopify.User.find(799407056)
 
         self.assertEqual("Steve", user.first_name)
         self.assertEqual("Jobs", user.last_name)
 
     def test_get_current_user(self):
-        self.fake('users/current', body=self.load_fixture('user'))
+        self.fake("users/current", body=self.load_fixture("user"))
         user = shopify.User.current()
 
         self.assertEqual("Steve", user.first_name)

--- a/test/variant_test.py
+++ b/test/variant_test.py
@@ -4,46 +4,46 @@ from test.test_helper import TestCase
 
 class VariantTest(TestCase):
     def test_get_variants(self):
-        self.fake("products/632910392/variants", method='GET', body=self.load_fixture('variants'))
+        self.fake("products/632910392/variants", method="GET", body=self.load_fixture("variants"))
         v = shopify.Variant.find(product_id=632910392)
 
     def test_get_variant_namespaced(self):
-        self.fake("products/632910392/variants/808950810", method='GET', body=self.load_fixture('variant'))
+        self.fake("products/632910392/variants/808950810", method="GET", body=self.load_fixture("variant"))
         v = shopify.Variant.find(808950810, product_id=632910392)
 
     def test_update_variant_namespace(self):
-        self.fake("products/632910392/variants/808950810", method='GET', body=self.load_fixture('variant'))
+        self.fake("products/632910392/variants/808950810", method="GET", body=self.load_fixture("variant"))
         v = shopify.Variant.find(808950810, product_id=632910392)
 
         self.fake(
             "products/632910392/variants/808950810",
-            method='PUT',
-            body=self.load_fixture('variant'),
-            headers={'Content-type': 'application/json'},
+            method="PUT",
+            body=self.load_fixture("variant"),
+            headers={"Content-type": "application/json"},
         )
         v.save()
 
     def test_create_variant(self):
         self.fake(
             "products/632910392/variants",
-            method='POST',
-            body=self.load_fixture('variant'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("variant"),
+            headers={"Content-type": "application/json"},
         )
-        v = shopify.Variant({'product_id': 632910392})
+        v = shopify.Variant({"product_id": 632910392})
         v.save()
 
     def test_create_variant_then_add_parent_id(self):
         self.fake(
             "products/632910392/variants",
-            method='POST',
-            body=self.load_fixture('variant'),
-            headers={'Content-type': 'application/json'},
+            method="POST",
+            body=self.load_fixture("variant"),
+            headers={"Content-type": "application/json"},
         )
         v = shopify.Variant()
         v.product_id = 632910392
         v.save()
 
     def test_get_variant(self):
-        self.fake("variants/808950810", method='GET', body=self.load_fixture('variant'))
+        self.fake("variants/808950810", method="GET", body=self.load_fixture("variant"))
         v = shopify.Variant.find(808950810)


### PR DESCRIPTION
### WHY are these changes introduced?

- a lot of files have both single quotes `'` and double quotes `"`
- this results in linting errors, for example `pylint` results in the following
![image](https://user-images.githubusercontent.com/40904028/109553598-373d0000-7aa1-11eb-9abf-97f817e3d31a.png)
- the [Shopify Python](https://github.com/Shopify/shopify_python) guide uses the [Google Python style guide](https://google.github.io/styleguide/pyguide.html) which asks users to [run pylint](https://google.github.io/styleguide/pyguide.html)
  - since we need to run Pylint, we need to fix the `inconsistent-quotes` errors first


### WHAT is this pull request doing?

- the only change I've made is to remove `skip-string-normalization = true` from `pyproject.toml`
- `black` automatically formats all of the quotes to double quotes, unless it would introduce more backslash escapes
- e.g. in the following example, it replaces the backslash escapes with outer single quotes
![image](https://user-images.githubusercontent.com/40904028/109554808-b8e15d80-7aa2-11eb-81a6-499397e94861.png)


### WHY double quotes? Single quotes are easier to type
> On certain keyboard layouts like US English, typing single quotes is a bit easier than double quotes. The latter requires use of the Shift key. My recommendation here is to keep using whatever is faster to type and let Black handle the transformation.
> - Black documentation

- an empty string in single quotes `''` can be confused with a single double quote symbol `"`
- double quotes are consistent with C, which Python interacts a lot with
- for more info read the [Black documentation on strings](https://black.readthedocs.io/en/stable/the_black_code_style.html#strings)


### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
