### PR TITLE
Add pre-commit badge to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/ShopifyAPI.svg)](https://badge.fury.io/py/ShopifyAPI)
 [![codecov](https://codecov.io/gh/Shopify/shopify_python_api/branch/master/graph/badge.svg?token=pNTx0TARUx)](https://codecov.io/gh/Shopify/shopify_python_api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Shopify/shopify_python_api/blob/master/LICENSE)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 The [Shopify Admin API](https://shopify.dev/docs/admin-api) Python Library
 


### PR DESCRIPTION
### WHY are these changes introduced?

- a badge shows users/contributors that we use pre-commit

### WHAT is this pull request doing?
- add pre-commit badge

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
