### PR TITLE
[Feature]: Add access scopes in Session object

### DIFF
--- a/shopify/api_access.py
+++ b/shopify/api_access.py
@@ -1,4 +1,12 @@
 import re
+import sys
+
+
+def basestring_type():
+    if sys.version_info[0] < 3:  # Backwards compatibility for python < v3.0.0
+        return basestring
+    else:
+        return str
 
 
 class ApiAccessError(Exception):
@@ -12,7 +20,7 @@ class ApiAccess:
     IMPLIED_SCOPE_RE = re.compile(r"\A(?P<unauthenticated>unauthenticated_)?write_(?P<resource>.*)\Z")
 
     def __init__(self, scopes):
-        if type(scopes) == str:
+        if isinstance(scopes, basestring_type()):
             scopes = scopes.split(self.SCOPE_DELIMITER)
 
         self.__store_scopes(scopes)
@@ -32,7 +40,6 @@ class ApiAccess:
     def __store_scopes(self, scopes):
         sanitized_scopes = frozenset(filter(None, [scope.strip() for scope in scopes]))
         self.__validate_scopes(sanitized_scopes)
-
         implied_scopes = frozenset(self.__implied_scope(scope) for scope in sanitized_scopes)
         self._compressed_scopes = sanitized_scopes - implied_scopes
         self._expanded_scopes = sanitized_scopes.union(implied_scopes)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We need to store access scopes in the `Session` object so that apps have access to the scope granted to them after OAuth. These scopes can then be used by apps to keep track of scopes granted.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Storing `access_scopes` as an instance variable in the `Session` object on construction and after access token exchanges.

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
