### PR TITLE
[Bug fix] Release v8.3.1: Add shopify/utils to setup.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+== Version 8.3.1
+- Fix bug: Add the `shopify/utils` sub-package when building the source distribution ([#493](https://github.com/Shopify/shopify_python_api/pull/493))
+
 == Version 8.3.0
 - Add support for [session tokens](https://shopify.dev/concepts/apps/building-embedded-apps-using-session-tokens) ([#479](https://github.com/Shopify/shopify_python_api/pull/479))
   - Use `session_token.decode_from_header` to obtain a decoded session token from an HTTP Authorization header

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author="Shopify",
     author_email="developers@shopify.com",
     url="https://github.com/Shopify/shopify_python_api",
-    packages=["shopify", "shopify/resources"],
+    packages=["shopify", "shopify/resources", "shopify/utils"],
     scripts=["scripts/shopify_api.py"],
     license="MIT License",
     install_requires=[

--- a/shopify/version.py
+++ b/shopify/version.py
@@ -1,1 +1,1 @@
-VERSION = "8.3.0"
+VERSION = "8.3.1"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

> This will also be a patch release 8.3.1

This change introduces a missing `shopify.utils` package inclusion in the library's setup.py file. This will include the `utils` package in the source distribution TAR file as well.

Right now, we get the following error trying to use `shopify.utils`:

```
ModuleNotFoundError: No module named 'shopify.utils'
```

### WHAT is this pull request doing?

* Add `shopify/utils` as a package for src distribution

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
