### PR TITLE
[Bug fix] - Return None when sanitizing shop domain if None passed in

### DIFF
--- a/shopify/utils/shop_url.py
+++ b/shopify/utils/shop_url.py
@@ -10,7 +10,7 @@ HOSTNAME_PATTERN = r"[a-z0-9][a-z0-9-]*[a-z0-9]"
 
 
 def sanitize_shop_domain(shop_domain, myshopify_domain="myshopify.com"):
-    name = str(shop_domain).lower().strip()
+    name = str(shop_domain or "").lower().strip()
     if myshopify_domain not in name and "." not in name:
         name += ".{domain}".format(domain=myshopify_domain)
     name = re.sub(r"https?://", "", name)

--- a/test/utils/shop_url_test.py
+++ b/test/utils/shop_url_test.py
@@ -42,3 +42,6 @@ class TestSanitizeShopDomain(TestCase):
         ]
 
         self.assertTrue(all(shop == "my-shop.myshopify.io" for shop in sanitized_shops))
+
+    def test_returns_none_for_none_type(self):
+        self.assertIsNone(shop_url.sanitize_shop_domain(None))


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

> **Bug:** `shop_url.sanitize_shop_domain(None)` returns `"none.myshopify.com"`
> * I just found out that `str(None) == "none"` in Python 😬 

~~This PR is intended to be a patch for shopify_python_api `v8.3`~~. It introduces a check to see if `shop_domain` is `None`.

### Releasing

~~I noticed that we've released `v8.4` already. Ideally, I'd like to release this as a patch for both `v8.4` and `v8.3.2`. Do we have a guide on how to do this?~~

This is intended to be a patch release.


### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
