### PR TITLE
Remove assignees field

### DIFF
--- a/.github/api_update_reminder.md
+++ b/.github/api_update_reminder.md
@@ -1,6 +1,5 @@
 ---
 title: A new release of the Shopify API is due soon
-assignees: "Shopify/platform-dev-tools-education"
 labels: automated
 ---
 

--- a/.github/api_update_reminder_on_release.md
+++ b/.github/api_update_reminder_on_release.md
@@ -1,6 +1,5 @@
 ---
 title: A new release of the Shopify API occurred
-assignees: "Shopify/platform-dev-tools-education"
 labels: automated
 ---
 


### PR DESCRIPTION
Assigning to a team seems to be problematic, so for now we'll manually assign these when created.