### PR TITLE
[WIP] [Feature] Add some basic logging around request/response process. 

### DIFF
--- a/shopify/base.py
+++ b/shopify/base.py
@@ -7,9 +7,10 @@ import threading
 import sys
 from six.moves import urllib
 import six
-
+import logging
 from shopify.collection import PaginatedCollection
 from pyactiveresource.collection import Collection
+log = logging.getLogger(__name__)
 
 # Store the response from the last request in the connection object
 
@@ -23,10 +24,14 @@ class ShopifyConnection(pyactiveresource.connection.Connection):
     def _open(self, *args, **kwargs):
         self.response = None
         try:
+            log.debug(f"Request: {args, kwargs}")
             self.response = super(ShopifyConnection, self)._open(*args, **kwargs)
+            log.debug(f'Response {self.response}')
         except pyactiveresource.connection.ConnectionError as err:
             self.response = err.response
+            log.exception(f"Exception with request: {args, kwargs}, Response: {self.response}")
             raise
+
         return self.response
 
 

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -13,6 +13,9 @@ from six.moves import urllib
 from shopify.api_access import ApiAccess
 from shopify.api_version import ApiVersion, Release, Unstable
 import six
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class ValidationException(Exception):
@@ -71,10 +74,13 @@ class Session(object):
         url = "https://%s/admin/oauth/access_token?" % self.url
         query_params = dict(client_id=self.api_key, client_secret=self.secret, code=code)
         request = urllib.request.Request(url, urllib.parse.urlencode(query_params).encode("utf-8"))
+        log.debug(f"Request URL: {url}, query params: {query_params}")
         response = urllib.request.urlopen(request)
+        logging.debug(f"Response: {response}")
 
         if response.code == 200:
             json_payload = json.loads(response.read().decode("utf-8"))
+            log.debug(f"Response: {json_payload}")
             self.token = json_payload["access_token"]
             self.access_scopes = json_payload["scope"]
 


### PR DESCRIPTION
Currently, problematic queries are difficult to debug, this should make slightly it easier.

### WHY are these changes introduced?
PR is opened to address this discussion: https://github.com/Shopify/shopify_python_api/issues/500

Fixes #500 


  Context about the problem that’s being addressed: 

 Adds some very rudimentary debug level logging in the session and base files. 

Further discussion: 
- I used f-strings, however I noticed that tox is still running tests for 2.7 and <3.7 all of which are EOL or will be shortly. Can we drop that support and move to currently supported python versions? If old python needs to be supported, I can switch them to something pre f-string. 
- this is flagged as a WIP because I know people will probably have strong feeling around the verbosity and format of the logs as well as the method for toggling them. We could use a -v flag/verbosity kwarg, the standard logging conventions, or really anything else that makes sense. 


### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
