### PR TITLE
Remove unused codecov secret token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,5 @@ jobs:
       - name: upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           name: codecov-umbrella
           fail_ci_if_error: true


### PR DESCRIPTION
### WHY are these changes introduced?

- there is a codecov token located in the `secrets` of this repo. From the docs we don't need this token and it might pose a security issue in the future 🥴 

### WHAT is this pull request doing?

- remove the codecov token from the workflow
- I'll remove the secret from the repo once this PR is merged 🎉 

### Additional comments
- it is an option to remove codecov fully, but as this is an open-source repo there are not secrets (other than the one I am removing now) that would be affected by future security vulnerabilities

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
