### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install --upgrade ShopifyAPI
     # redirect to auth_url
     ```
 
-1. Once the merchant accepts, the shop redirects the owner to the `redirect_uri` of your application with a parameter named 'code'. This is a temporary token that the app can exchange for a permanent access token. You should compare the state you provided above with the one you recieved back to ensure the request is correct. Now we can exchange the code for an access_token when you get the request from shopify in your callback handler:
+1. Once the merchant accepts, the shop redirects the owner to the `redirect_uri` of your application with a parameter named 'code'. This is a temporary token that the app can exchange for a permanent access token. You should compare the state you provided above with the one you received back to ensure the request is correct. Now we can exchange the code for an access_token when you get the request from shopify in your callback handler:
 
     ```python
     session = shopify.Session(shop_url, api_version)

--- a/docs/api-access.md
+++ b/docs/api-access.md
@@ -24,7 +24,7 @@ another_api_access = ApiAccess("read_products, write_products, unauthenticated_r
 api_access = ApiAccess(["read_products", "write_orders", "unauthenticated_read_themes"])
 
 access_scopes_list = list(api_access) # ["read_products", "write_orders", "unauthenticated_read_themes"]
-comma_delmited_access_scopes = str(api_access) # "read_products,write_orders,unauthenticated_read_themes"
+comma_delimited_access_scopes = str(api_access) # "read_products,write_orders,unauthenticated_read_themes"
 ```
 
 ### Comparing ApiAccess objects
@@ -60,7 +60,7 @@ from shopify import ApiAccess
 
 def oauth_on_access_scopes_mismatch(func):
   def wrapper(*args, **kwargs):
-    shop_domain = get_shop_query_paramer(request) # shop query param when loading app
+    shop_domain = get_shop_query_parameter(request) # shop query param when loading app
     current_shop_scopes = ApiAccess(ShopStore.get_record(shopify_domain = shop_domain).access_scopes)
     expected_access_scopes = ApiAccess(SHOPIFY_API_SCOPES)
 

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -58,7 +58,7 @@ class TasksMeta(type):
             cls.help()
             return
 
-        # Allow unambigious abbreviations of tasks
+        # Allow unambiguous abbreviations of tasks
         if task not in cls._tasks:
             matches = filter(lambda item: item.startswith(task), cls._tasks)
             list_of_matches = list(matches)


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/api-access.md
- scripts/shopify_api.py

Fixes:
- Should read `unambiguous` rather than `unambigious`.
- Should read `received` rather than `recieved`.
- Should read `delimited` rather than `delmited`.
- Should read `parameter` rather than `paramer`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md