### PR TITLE
Suggestion for supporting ongoing API version releases

### DIFF
--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -32,8 +32,8 @@ class ApiVersion(object):
     def define_known_versions(cls):
         cls.define_version(Unstable())
         # Generate quarterly API versions thru next release candidate
-        ver_yr = int(MIN_API_VERSION.split('-')[0])
-        ver_mo = int(MIN_API_VERSION.split('-')[1])
+        ver_yr = int(MIN_API_VERSION.split("-")[0])
+        ver_mo = int(MIN_API_VERSION.split("-")[1])
         now = datetime.utcnow()
         while ver_yr <= now.year + 1:
             cls.define_version(Release("{0}-{1:02}".format(ver_yr, ver_mo)))

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -1,4 +1,8 @@
 import re
+from datetime import datetime
+
+
+MIN_API_VERSION = "2019-04"
 
 
 class InvalidVersionError(Exception):
@@ -27,12 +31,18 @@ class ApiVersion(object):
     @classmethod
     def define_known_versions(cls):
         cls.define_version(Unstable())
-        cls.define_version(Release("2020-04"))
-        cls.define_version(Release("2020-07"))
-        cls.define_version(Release("2020-10"))
-        cls.define_version(Release("2021-01"))
-        cls.define_version(Release("2021-04"))
-        cls.define_version(Release("2021-07"))
+        # Generate quarterly API versions thru next release candidate
+        ver_yr = int(MIN_API_VERSION.split('-')[0])
+        ver_mo = int(MIN_API_VERSION.split('-')[1])
+        now = datetime.utcnow()
+        while ver_yr <= now.year + 1:
+            cls.define_version(Release("{0}-{1:02}".format(ver_yr, ver_mo)))
+            if ver_yr > now.year or ver_mo > now.month:
+                break
+            ver_mo += 3
+            if ver_mo > 12:
+                ver_yr += 1
+                ver_mo = 1
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION
Be less rigid with API versions. Having to manually update this repo every three months is getting cumbersome it seems and we are lagging behind by weeks in getting the new versions supported as they are released by Shopify. This repo doesn't need to strictly enforce the deprecations and new releases. Developers can still make a request to the 2019-04 api version successfully so there isn't a major need IMO to block deprecated API versions if a developer chooses to use. Further, each new release and the next release candidate should be usable/testable here without having to override.

### WHY are these changes introduced?

Addresses original issue #[339](https://github.com/Shopify/shopify_python_api/issues/339) for which a fix was attempted in #[441](https://github.com/Shopify/shopify_python_api/pull/441) but caused more problems than solved. 

### WHAT is this pull request doing?

Replacing a fixed, hard-coded list of supported/valid API versions with an allowable range of all API versions plus new ones automatically going forward including next release candidate.

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide

I did not update these items awaiting acceptance or review/discussion of this PR.