### PR TITLE
Add operation_name parameter to Graphql.execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ This library also supports Shopify's new [GraphQL API](https://help.shopify.com/
 result = shopify.GraphQL().execute('{ shop { name id } }')
 ```
 
-You can perform more complex operations using the `variables` and `operation_name` parameters of `execute`. 
+You can perform more complex operations using the `variables` and `operation_name` parameters of `execute`.
 
-For example, this GraphQL document uses a fragment to construct two named queries - one for a single order, and one for multiple orders:  
+For example, this GraphQL document uses a fragment to construct two named queries - one for a single order, and one for multiple orders:
 
 ```graphql
     # ./order_queries.graphql
@@ -195,13 +195,13 @@ For example, this GraphQL document uses a fragment to construct two named querie
         name
         createdAt
     }
-    
+
     query GetOneOrder($order_id: ID!){
         node(id: $order_id){
             ...OrderInfo
         }
     }
-    
+
     query GetManyOrders($order_ids: [ID]!){
         nodes(ids: $order_ids){
            ...OrderInfo
@@ -209,7 +209,7 @@ For example, this GraphQL document uses a fragment to construct two named querie
     }
 ```
 
-Now you can chose which operation to execute:       
+Now you can chose which operation to execute:
 
 ```python
 # Load the document with both queries

--- a/README.md
+++ b/README.md
@@ -183,6 +183,45 @@ This library also supports Shopify's new [GraphQL API](https://help.shopify.com/
 result = shopify.GraphQL().execute('{ shop { name id } }')
 ```
 
+You can perform more complex operations using the `variables` and `operation_name` parameters of `execute`. 
+
+For example, this GraphQL document uses a fragment to construct two named queries - one for a single order, and one for multiple orders:  
+
+```graphql
+    # ./order_queries.graphql
+
+    fragment orderInfo on Order {
+        id
+        name
+        createdAt
+    }
+    
+    query GetOneOrder($order_id: ID!){
+        node(id: $order_id){
+            ...OrderInfo
+        }
+    }
+    
+    query GetManyOrders($order_ids: [ID]!){
+        nodes(ids: $order_ids){
+           ...OrderInfo
+        }
+    }
+```
+
+Now you can chose which operation to execute:       
+
+```python
+# Load the document with both queries
+document = Path("./order_queries.graphql").read_text()
+
+# Specify the named operation to execute, and the parameters for the query
+result = shopify.GraphQL().execute(
+    query=document,
+    variables={"order_id": "gid://shopify/Order/12345"},
+    operation_name="GetOneOrder",
+)
+```
 
 ## Using Development Version
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ For example, this GraphQL document uses a fragment to construct two named querie
 ```graphql
     # ./order_queries.graphql
 
-    fragment orderInfo on Order {
+    fragment OrderInfo on Order {
         id
         name
         createdAt

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ For example, this GraphQL document uses a fragment to construct two named querie
     }
 ```
 
-Now you can chose which operation to execute:
+Now you can choose which operation to execute:
 
 ```python
 # Load the document with both queries

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -15,11 +15,11 @@ class GraphQL:
             merged_headers.update(header)
         return merged_headers
 
-    def execute(self, query, variables=None):
+    def execute(self, query, variables=None, operation_name=None):
         endpoint = self.endpoint
         default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
         headers = self.merge_headers(default_headers, self.headers)
-        data = {"query": query, "variables": variables}
+        data = {"query": query, "variables": variables, "operationName": operation_name}
 
         req = urllib.request.Request(self.endpoint, json.dumps(data).encode("utf-8"), headers)
 

--- a/test/graphql_test.py
+++ b/test/graphql_test.py
@@ -9,7 +9,7 @@ class GraphQLTest(TestCase):
         shopify.ApiVersion.define_known_versions()
         shopify_session = shopify.Session("this-is-my-test-show.myshopify.com", "unstable", "token")
         shopify.ShopifyResource.activate_session(shopify_session)
-        client = shopify.GraphQL()
+        self.client = shopify.GraphQL()
         self.fake(
             "graphql",
             method="POST",
@@ -20,6 +20,8 @@ class GraphQLTest(TestCase):
                 "Content-Type": "application/json",
             },
         )
+
+    def test_fetch_shop_with_graphql(self):
         query = """
             {
                 shop {
@@ -28,7 +30,17 @@ class GraphQLTest(TestCase):
                 }
             }
         """
-        self.result = client.execute(query)
+        result = self.client.execute(query)
+        self.assertTrue(json.loads(result)["shop"]["name"] == "Apple Computers")
 
-    def test_fetch_shop_with_graphql(self):
-        self.assertTrue(json.loads(self.result)["shop"]["name"] == "Apple Computers")
+    def test_specify_operation_name(self):
+        query = """
+            query GetShop{
+                shop {
+                    name
+                    id
+                }
+            }
+        """
+        result = self.client.execute(query, operation_name="GetShop")
+        self.assertTrue(json.loads(result)["shop"]["name"] == "Apple Computers")


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
When constructing non-trivial GraphQL queries, it can be helpful to have multiple NamedOperations in the same document. 
For example, I could have a fragment which I'd like to reuse between two queries:

```graphql
    fragment orderInfo on Order {
        id
        name
        createdAt
    }
    
    query GetOneOrder($order_id: ID!){
        node(id: $order_id){
            ...OrderInfo
        }
    }
    
    query GetManyOrders($order_ids: [ID]!){
        nodes(ids: $order_ids){
           ...OrderInfo
        }
    }
```

From [the GraphQL docs](https://graphql.org/learn/serving-over-http/#post-request), an "operationName" parameter can be included in the POST request to specify which operation should be performed. 

When sending a manual GraphQL POST request to Shopify, the "operationName" parameter is accepted / respected. 

**Currently**,  
There is no way to specify this operationName as a POST parameter when using the `execute()` method from Shopify's `GraphQL` helper client. 

The body of the post request is being constructed [here](https://github.com/Shopify/shopify_python_api/blob/master/shopify/resources/graphql.py#L22).

### WHAT is this pull request doing?
This PR adds an `operation_name` parameter to the `execute()` method in question. The value will added to the body of POST request, under the "operationName" key. 

The presence of `operationName` in the request is handled by the Shopify GraphQL server, which will execute the correct operation and return the results as normal.

The README has also been updated with this example of a more complex GraphQL query, using both the new `operation_name` and the existing `variables` parameters.

<!--
  Summary of the changes committed.
-->

### Checklist

- [X] I have updated the CHANGELOG (if applicable)
  -  This doesn't seem big enough to update the CHANGELOG, but I'd be happy to do so if a maintainer disagrees.
- [X] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
