### PR TITLE
add timeout for graphql requests

### DIFF
--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -15,7 +15,7 @@ class GraphQL:
             merged_headers.update(header)
         return merged_headers
 
-    def execute(self, query, variables=None, operation_name=None):
+    def execute(self, query, variables=None, operation_name=None, timeout=None):
         endpoint = self.endpoint
         default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
         headers = self.merge_headers(default_headers, self.headers)
@@ -24,7 +24,7 @@ class GraphQL:
         req = urllib.request.Request(self.endpoint, json.dumps(data).encode("utf-8"), headers)
 
         try:
-            response = urllib.request.urlopen(req)
+            response = urllib.request.urlopen(req, timeout=timeout)
             return response.read().decode("utf-8")
         except urllib.error.HTTPError as e:
             print((e.read()))


### PR DESCRIPTION
### WHY are these changes introduced?

I realized that shopify servers sometimes doesn't respond and the code halts. Giving an optional timeout parameter would fix the issue.

### WHAT is this pull request doing?

Adding an optional timeout parameter to the execute method of GraphQL Class in shopify/resources/graphql.py on line 18 and using that parameter on line 27.

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [+] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
