### PR TITLE
Update to 2022-07 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 == Unreleased
 
+- Update API version with 2022-04 release, remove API version 2021-07
+
 == Version 11.0.0
 - Update API version with 2022-04 release
 - remove API version 2020-10, 2021-01, 2021-04 as they are all unsupported as of 2022-04

--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ name: shopify-python-api
 type: python
 
 up:
-  - python: 3.8.0
+  - python: 3.8.13
   - pip:
       - requirements.txt
 

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -27,10 +27,10 @@ class ApiVersion(object):
     @classmethod
     def define_known_versions(cls):
         cls.define_version(Unstable())
-        cls.define_version(Release("2021-07"))
         cls.define_version(Release("2021-10"))
         cls.define_version(Release("2022-01"))
         cls.define_version(Release("2022-04"))
+        cls.define_version(Release("2022-07"))
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION
Closes #584
Closes #590

This PR removes support for the `2021-07` API version, and adds support for `2022-07`.