### PR TITLE
[FIX] Fix Gift Card Adjustment

### DIFF
--- a/shopify/resources/gift_card_adjustment.py
+++ b/shopify/resources/gift_card_adjustment.py
@@ -2,6 +2,6 @@ from ..base import ShopifyResource
 
 
 class GiftCardAdjustment(ShopifyResource):
-    _prefix_source = "/admin/gift_cards/$gift_card_id/"
+    _prefix_source = "/gift_cards/$gift_card_id/"
     _plural = "adjustments"
     _singular = "adjustment"


### PR DESCRIPTION
### WHY are these changes introduced?

According to the api (https://shopify.dev/api/admin-rest/2022-07/resources/gift-card-adjustment#get-gift-cards-gift-card-id-adjustments), the url should not include /admin before /gift_cards. This commit removes the /admin in order to make it working

### WHAT is this pull request doing?

Remove the /admin path from the prefix source of GiftCardAdjustment

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
