### PR TITLE
Improve: Stop printing an error response on a GraphQL error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 == Unreleased
+- Improve: Stop reading and printing an HTTPError message on a GraphQL error
 
 == Version 12.0.0
 - Update API version with 2022-04 release, remove API version 2021-07 ([#591](https://github.com/Shopify/shopify_python_api/pull/591))

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -1,5 +1,4 @@
 import shopify
-from ..base import ShopifyResource
 from six.moves import urllib
 import json
 
@@ -16,17 +15,11 @@ class GraphQL:
         return merged_headers
 
     def execute(self, query, variables=None, operation_name=None):
-        endpoint = self.endpoint
         default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
         headers = self.merge_headers(default_headers, self.headers)
         data = {"query": query, "variables": variables, "operationName": operation_name}
 
         req = urllib.request.Request(self.endpoint, json.dumps(data).encode("utf-8"), headers)
 
-        try:
-            response = urllib.request.urlopen(req)
-            return response.read().decode("utf-8")
-        except urllib.error.HTTPError as e:
-            print((e.read()))
-            print("")
-            raise e
+        response = urllib.request.urlopen(req)
+        return response.read().decode("utf-8")


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

`shopify.GraphQL().execute()` prints an error message when an HTTPError is thrown while calling the GraphQL endpoint. This behaviour prevents client codes from reading HTTPError message body.

### WHAT is this pull request doing?

* Stop reading and printing an error reponse on a GraphQL error.
* Remove dead codes.

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
