### PR TITLE
[Update] README.md Additional Resources section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,9 @@ Currently there is no support for:
 * persistent connections
 
 ## Additional Resources
-* [Partners Dashboard](https://partners.shopify.com)
-* [developers.shopify.com](https://developers.shopify.com)
+* [Partners Dashboard](https://www.shopify.com/partners)
 * [Shopify.dev](https://shopify.dev)
-* [Ask questions on the Shopify forums](http://ecommerce.shopify.com/c/shopify-apis-and-technology)
+* [Ask questions on the Shopify forums](https://community.shopify.com/c/shopify-apis-and-sdks/bd-p/shopify-apis-and-technology)
 
 ### Sample apps built using this library
 * [Sample Django app](https://github.com/shopify/sample-django-app)


### PR DESCRIPTION
No need to change the CHANGELOG, nor Python update on this PR

### WHY are these changes introduced?

1. http://ecommerce.shopify.com/c/shopify-apis-and-technology redirects to another page
3. https://www.shopify.com/tour/ecommerce-website developers.shopify.com == Shopify.dev, so I am removing the duplicate
4. https://partners.shopify.com redirects to https://www.shopify.com/partners

### WHAT is this pull request doing?

1. Changing http://ecommerce.shopify.com/c/shopify-apis-and-technology to https://community.shopify.com/c/shopify-apis-and-sdks/bd-p/shopify-apis-and-technology (the API section on Community)
2. Removing the duplicate since both links are redirecting to the same page
3. Changing https://partners.shopify.com to https://www.shopify.com/partners

### Checklist

- <s> I have updated the CHANGELOG (if applicable)</s>
- <s>  I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide</s> 
