### PR TITLE
Add Jan 23 version, deprecate Jan 22

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 == Unreleased
+- Update API version with 2023-01 release, remove API version 2022-01
 - Update API version with 2022-10 release, remove API version 2021-10
 
 == Version 12.0.1

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -27,10 +27,10 @@ class ApiVersion(object):
     @classmethod
     def define_known_versions(cls):
         cls.define_version(Unstable())
-        cls.define_version(Release("2022-01"))
         cls.define_version(Release("2022-04"))
         cls.define_version(Release("2022-07"))
         cls.define_version(Release("2022-10"))
+        cls.define_version(Release("2023-01"))
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION
### WHY are these changes introduced?

Preparing for Jan 2023 release

### WHAT is this pull request doing?

Updating the `api_version.py` file to remove `"2022-01"` and add `"2023-01"`

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
