### PR TITLE
Add 2022-10 back into api_version.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 == Unreleased
-- Update API version with 2022-10 release, remove API version 2021-10
+- Add API version with 2022-10 release
 
 == Version 12.0.1
 - Allow up to 10 seconds clock skew to avoid `ImmatureSignatureError`

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -27,6 +27,7 @@ class ApiVersion(object):
     @classmethod
     def define_known_versions(cls):
         cls.define_version(Unstable())
+        cls.define_version(Release("2021-10"))
         cls.define_version(Release("2022-01"))
         cls.define_version(Release("2022-04"))
         cls.define_version(Release("2022-07"))


### PR DESCRIPTION
### WHAT is this pull request doing?

Adds `"2021-10"` back into `api_version.py` to do a minor release

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
