### PR TITLE
feat: update API version to 2023-01

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 == Unreleased
+- Update API version with 2023-01 release
+- remove API version 2021-10, 2022-01 as they are all unsupported as of 2023-01
 
 == Version 12.1.0
 - Add API version with 2022-10 release

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -27,11 +27,10 @@ class ApiVersion(object):
     @classmethod
     def define_known_versions(cls):
         cls.define_version(Unstable())
-        cls.define_version(Release("2021-10"))
-        cls.define_version(Release("2022-01"))
         cls.define_version(Release("2022-04"))
         cls.define_version(Release("2022-07"))
         cls.define_version(Release("2022-10"))
+        cls.define_version(Release("2023-01"))
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION
Following update from #614 based on latest API release on Jan 1, 2023.

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
