### PR TITLE
[WIP] [FIX] Fix URL generation for Fulfillment

### DIFF
--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -5,6 +5,14 @@ import json
 class Fulfillment(ShopifyResource):
     _prefix_source = "/orders/$order_id/"
 
+    @classmethod
+    def _prefix(cls, options={}):
+        order_id = options.get("order_id")
+        if order_id:
+            return "%s/orders/%s" % (cls.site, order_id)
+        else:
+            return cls.site
+    
     def cancel(self):
         self._load_attributes_from_response(self.post("cancel"))
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fix Fulfillment.py to generate the correct URL for API 2023-01.

If no order_id supplied, URL should be /admin/api/<api_version>/fulfillments.py

currently the library produces the URL

/admin/api/<api_version>/orders//fulfillments.py

See issue #634

### WHAT is this pull request doing?

Modifying the code in Fulfillment that generates the URL so that it complies with the requirements for API version 2023-01

**NOTE:** The added code is based on code already in the library for other resource classes
### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
