### PR TITLE
Fix and enchance Fulfillment and FulfillmentOrder after breaking changes of 2022-07

### DIFF
--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -29,7 +29,15 @@ class Fulfillment(ShopifyResource):
 
 
 class FulfillmentOrders(ShopifyResource):
-    _prefix_source = "/orders/$order_id/"
+    @classmethod
+    def _prefix(cls, options=None):
+        if options is None:
+            options = {}
+        order_id = options.get("order_id")
+        if order_id:
+            return "%s/orders/%s" % (cls.site, order_id)
+        else:
+            return cls.site
 
 
 class FulfillmentV2(ShopifyResource):

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -23,9 +23,8 @@ class Fulfillment(ShopifyResource):
         self._load_attributes_from_response(self.post("open"))
 
     def update_tracking(self, tracking_info, notify_customer):
-        fulfill = FulfillmentV2()
-        fulfill.id = self.id
-        self._load_attributes_from_response(fulfill.update_tracking(tracking_info, notify_customer))
+        body = {"fulfillment": {"tracking_info": tracking_info, "notify_customer": notify_customer}}
+        return self.post("update_tracking", json.dumps(body).encode())
 
 
 class FulfillmentOrders(ShopifyResource):
@@ -38,12 +37,3 @@ class FulfillmentOrders(ShopifyResource):
             return "%s/orders/%s" % (cls.site, order_id)
         else:
             return cls.site
-
-
-class FulfillmentV2(ShopifyResource):
-    _singular = "fulfillment"
-    _plural = "fulfillments"
-
-    def update_tracking(self, tracking_info, notify_customer):
-        body = {"fulfillment": {"tracking_info": tracking_info, "notify_customer": notify_customer}}
-        return self.post("update_tracking", json.dumps(body).encode())

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -1,17 +1,21 @@
-from ..base import ShopifyResource
 import json
+
+from ..base import ShopifyResource
 
 
 class Fulfillment(ShopifyResource):
+    _prefix_sources = {
+        ("order_id",): "/orders/$order_id/",
+        ("fulfillment_order_id",): "/fulfillment_orders/$fulfillment_order_id/",
+    }
+
     @classmethod
-    def _prefix(cls, options=None):
-        if options is None:
-            options = {}
-        order_id = options.get("order_id")
-        if order_id:
-            return "%s/orders/%s" % (cls.site, order_id)
-        else:
-            return cls.site
+    def _split_options(cls, options):
+        if cls._prefix_sources and options:
+            if cls._prefix_sources.get(tuple(options)):
+                cls._prefix_source = cls._prefix_sources[tuple(options)]
+
+        return super()._split_options(options)
 
     def cancel(self):
         self._load_attributes_from_response(self.post("cancel"))
@@ -28,12 +32,14 @@ class Fulfillment(ShopifyResource):
 
 
 class FulfillmentOrders(ShopifyResource):
+    _prefix_sources = {
+        ("order_id",): "/orders/$order_id/",
+    }
+
     @classmethod
-    def _prefix(cls, options=None):
-        if options is None:
-            options = {}
-        order_id = options.get("order_id")
-        if order_id:
-            return "%s/orders/%s" % (cls.site, order_id)
-        else:
-            return cls.site
+    def _split_options(cls, options):
+        if cls._prefix_sources and options:
+            if cls._prefix_sources.get(tuple(options)):
+                cls._prefix_source = cls._prefix_sources[tuple(options)]
+
+        return super()._split_options(options)

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -8,7 +8,7 @@ class Fulfillment(ShopifyResource):
         ("order_id",): "/orders/$order_id/",
         ("fulfillment_order_id",): "/fulfillment_orders/$fulfillment_order_id/",
     }
-    # cla
+
     @classmethod
     def _split_options(cls, options):
         if cls._prefix_sources and options:

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -8,7 +8,7 @@ class Fulfillment(ShopifyResource):
         ("order_id",): "/orders/$order_id/",
         ("fulfillment_order_id",): "/fulfillment_orders/$fulfillment_order_id/",
     }
-
+    # cla
     @classmethod
     def _split_options(cls, options):
         if cls._prefix_sources and options:

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -3,7 +3,15 @@ import json
 
 
 class Fulfillment(ShopifyResource):
-    _prefix_source = "/orders/$order_id/"
+    @classmethod
+    def _prefix(cls, options=None):
+        if options is None:
+            options = {}
+        order_id = options.get("order_id")
+        if order_id:
+            return "%s/orders/%s" % (cls.site, order_id)
+        else:
+            return cls.site
 
     def cancel(self):
         self._load_attributes_from_response(self.post("cancel"))

--- a/shopify/resources/fulfillment.py
+++ b/shopify/resources/fulfillment.py
@@ -12,8 +12,9 @@ class Fulfillment(ShopifyResource):
     @classmethod
     def _split_options(cls, options):
         if cls._prefix_sources and options:
-            if cls._prefix_sources.get(tuple(options)):
-                cls._prefix_source = cls._prefix_sources[tuple(options)]
+            options_tuples = tuple(options)
+            if options_tuples in cls._prefix_sources:
+                cls._prefix_source = cls._prefix_sources[options_tuples]
 
         return super()._split_options(options)
 
@@ -39,7 +40,8 @@ class FulfillmentOrders(ShopifyResource):
     @classmethod
     def _split_options(cls, options):
         if cls._prefix_sources and options:
-            if cls._prefix_sources.get(tuple(options)):
+            options_tuples = tuple(options)
+            if options_tuples in cls._prefix_sources:
                 cls._prefix_source = cls._prefix_sources[tuple(options)]
 
         return super()._split_options(options)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #634 <!-- link to issue if one exists -->

The _prefix_source being set to "/orders/$order_id/" in the Fulfillment and FulfillmentOrder classes, combined with the deprecation of the old order's fulfillment resource that entered a breaking state in 2022-07, has led to errors when using some of the Fulfillment endpoints. For more details, refer to the [Shopify Changelogs](https://shopify.dev/docs/api/release-notes/2022-07#fulfillment-endpoints-removed-from-the-rest-admin-api).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Fixing 2022-07 breaking changes
- Enable the use of both every `Fulfillment` and `FulfillmentOrders` endpoints, which was not possible.
- Remove FulfillmentV2 and transfer the update_tracking method from FulfillmentV2 to Fulfillment, as it is no longer necessary due to the removal of the _prefix_source attribute definition. Refer to this [Pull Request](https://github.com/Shopify/shopify_python_api/pull/432) for more information.

<!--
  Summary of the changes committed.
-->

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
