### PR TITLE
Bump api_version.py - 2023-07 API Version

### DIFF
--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -34,6 +34,7 @@ class ApiVersion(object):
         cls.define_version(Release("2022-10"))
         cls.define_version(Release("2023-01"))
         cls.define_version(Release("2023-04"))
+        cls.define_version(Release("2023-07"))
 
     @classmethod
     def clear_defined_versions(cls):


### PR DESCRIPTION


### WHY are these changes introduced?

https://shopify.dev/docs/api/usage/versioning

We have now reached api version 2023-07. To allow developers to keep up to date with the most recent version we just need to put the API version in the recognized versions.

### WHAT is this pull request doing?

Updating validation of API Version to make sure the most recent one is compatible.

### Checklist

- [ x ] I have updated the CHANGELOG (if applicable)
- [ x ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
