### PR TITLE
Replace print with logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 == Unreleased
 
+- Replace `print` with `logging` ([#678](https://github.com/Shopify/shopify_python_api/issues/678))
+
 == Version 12.3.0
 
 - Update API version with 2023-04 release ([#649](https://github.com/Shopify/shopify_python_api/pull/649))

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -1,7 +1,11 @@
+import logging
+
 import shopify
 from ..base import ShopifyResource
 from six.moves import urllib
 import json
+
+logger = logging.getLogger(__name__)
 
 
 class GraphQL:
@@ -27,6 +31,5 @@ class GraphQL:
             response = urllib.request.urlopen(req)
             return response.read().decode("utf-8")
         except urllib.error.HTTPError as e:
-            print((e.read()))
-            print("")
+            logger.exception("GraphQL error response:\n%s" % e.read())
             raise e


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #678

Replacing raw `print` to stdout with `logging` to allow consuming applications decide how they want this data to be presented

### WHAT is this pull request doing?

Replaced `print` with `logging.Logger.exception`. By default logging in Python prints all events with severity `>= WARNING` to the stdout/stderr so the existing behavior is maintained in general

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
