### PR TITLE
Fix collection.py for Python 3.13

### DIFF
--- a/shopify/collection.py
+++ b/shopify/collection.py
@@ -1,6 +1,5 @@
 from pyactiveresource.collection import Collection
 from six.moves.urllib.parse import urlparse, parse_qs
-import cgi
 
 
 class PaginatedCollection(Collection):


### PR DESCRIPTION
* removed unused 'cgi' reference (deprecated after 3.12)

### WHY are these changes introduced?

Fixes deprecation of 'cgi' in Python 3.13 (deprecated warnings in 3.12)

### WHAT is this pull request doing?

Removing unused reference to cgi

### Checklist

- [X] I have updated the CHANGELOG (if applicable)
- [X] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
