### PR TITLE
Remove CI failure for codecov task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Tests
         run: python -m pytest -v
       - name: upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v1
         with:
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
### WHY are these changes introduced?

* We are seeing increasing failures due to the codecov task
* We are not actively using this at this time

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
-->

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
