### PR TITLE
Improve the way of importing the `VERSION` constant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup
 
+from shopify.version import VERSION
+
 NAME = "ShopifyAPI"
-exec(open("shopify/version.py").read())
 DESCRIPTION = "Shopify API for Python"
 LONG_DESCRIPTION = """\
 The ShopifyAPI library allows python developers to programmatically


### PR DESCRIPTION
When having a file with one single line declaring a constant  (the `shopify.version` module), loading it by using `exec()` is a pretty weird method. You should just import the constant instead. This improves code readability and follows best practices for importing modules

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
