### PR TITLE
Fix(725): Add support for building the package in Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/Shopify/shopify_python_api/workflows/CI/badge.svg)](https://github.com/Shopify/shopify_python_api/actions)
 [![PyPI version](https://badge.fury.io/py/ShopifyAPI.svg)](https://badge.fury.io/py/ShopifyAPI)
+![Supported Python Versions](https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12-brightgreen)
 [![codecov](https://codecov.io/gh/Shopify/shopify_python_api/branch/main/graph/badge.svg?token=pNTx0TARUx)](https://codecov.io/gh/Shopify/shopify_python_api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Shopify/shopify_python_api/blob/main/LICENSE)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
     install_requires=[
         "pyactiveresource>=2.2.2",
         "PyJWT >= 2.0.0",
-        "PyYAML",
+        "PyYAML>=6.0.1; python_version>='3.12'",
+        "PyYAML; python_version<'3.12'",
         "six",
     ],
     test_suite="test",
@@ -44,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
### Description
As discussed in the [issue](https://github.com/Shopify/shopify_python_api/issues/725), there is an issue when installing this package using Python 3.12. The problem is caused by
[PEP-632](https://peps.python.org/pep-0632/) removes `distutils` from the built-in libraries this version of Python is shipped with. In versions 6.0.0 and lower of PyYaml, this causes the build to fail. As mentioned in their [issue](https://github.com/yaml/pyyaml/issues/756), using v6.0.1 or later will resolve this issue. So, we are updating our `setup.py` install_requires dependency specifications to reflect this.

While I'm here, I've also updated the classifiers to include support for PY3.12 and show this more clearly in the repo's README.

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
