### PR TITLE
Remove validation of API version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 == Unreleased
+- Remove requirement to use a predefined API version. Now you can use any valid API version string. ([#737](https://github.com/Shopify/shopify_python_api/pull/737))
 
 == Version 12.6.0
 

--- a/shopify/api_version.py
+++ b/shopify/api_version.py
@@ -17,6 +17,9 @@ class ApiVersion(object):
         try:
             return cls.versions[version]
         except KeyError:
+            # Dynamically create a new Release object if version string is not found
+            if Release.FORMAT.match(version):
+                return Release(version)
             raise VersionNotFoundError
 
     @classmethod
@@ -39,6 +42,7 @@ class ApiVersion(object):
         cls.define_version(Release("2024-01"))
         cls.define_version(Release("2024-04"))
         cls.define_version(Release("2024-07"))
+        cls.define_version(Release("2024-10"))
 
     @classmethod
     def clear_defined_versions(cls):

--- a/test/api_version_test.py
+++ b/test/api_version_test.py
@@ -29,6 +29,20 @@ class ApiVersionTest(TestCase):
         with self.assertRaises(shopify.VersionNotFoundError):
             shopify.ApiVersion.coerce_to_version("crazy-name")
 
+    def test_coerce_to_version_creates_new_release_on_the_fly(self):
+        new_version = "2025-01"
+        coerced_version = shopify.ApiVersion.coerce_to_version(new_version)
+
+        self.assertIsInstance(coerced_version, shopify.Release)
+        self.assertEqual(coerced_version.name, new_version)
+        self.assertEqual(
+            coerced_version.api_path("https://test.myshopify.com"),
+            f"https://test.myshopify.com/admin/api/{new_version}",
+        )
+
+        # Verify that the new version is not added to the known versions
+        self.assertNotIn(new_version, shopify.ApiVersion.versions)
+
 
 class ReleaseTest(TestCase):
     def test_raises_if_format_invalid(self):

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -288,3 +288,16 @@ class SessionTest(TestCase):
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
         query = "&".join(sorted(query.split("&")))
         return urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))
+
+    def test_session_with_coerced_version(self):
+        future_version = "2030-01"
+        session = shopify.Session("test.myshopify.com", future_version, "token")
+        self.assertEqual(session.api_version.name, future_version)
+        self.assertEqual(
+            session.api_version.api_path("https://test.myshopify.com"),
+            f"https://test.myshopify.com/admin/api/{future_version}",
+        )
+
+    def test_session_with_invalid_version(self):
+        with self.assertRaises(shopify.VersionNotFoundError):
+            shopify.Session("test.myshopify.com", "invalid-version", "token")


### PR DESCRIPTION
### WHY are these changes introduced?

Allow the use of API versions that are not previously defined

### WHAT is this pull request doing?

* If the string passed in was not a previously defined release, make a new release on the fly

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [ ] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
