### PR TITLE
drop "six" usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,4 @@ Please open an issue here if you encounter a specific bug with this API client l
 
 General questions about the Shopify API and usage of this package (not necessarily a bug) should be posted on the [Shopify forums](https://ecommerce.shopify.com/c/shopify-apis-and-technology).
 
-For compatibility across Python 2 and Python 3, look into [Six](https://six.readthedocs.io/).
-
 When in doubt, post on the forum first. You'll likely have your questions answered more quickly if you post there; more people monitor the forum than Github.

--- a/pylintrc
+++ b/pylintrc
@@ -335,7 +335,7 @@ callbacks=cb_,_cb
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+redefining-builtins-modules=future.builtins,functools
 
 
 [LOGGING]

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -9,8 +9,6 @@ import glob
 import subprocess
 import functools
 import yaml
-import six
-from six.moves import input, map
 
 
 def start_interpreter(**variables):
@@ -106,8 +104,7 @@ class TasksMeta(type):
             print(task_func.__doc__)
 
 
-@six.add_metaclass(TasksMeta)
-class Tasks(object):
+class Tasks(metaclass=TasksMeta):
     _shop_config_dir = os.path.join(os.environ["HOME"], ".shopify", "shops")
     _default_symlink = os.path.join(_shop_config_dir, "default")
     _default_api_version = "unstable"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "PyJWT >= 2.0.0",
         "PyYAML>=6.0.1; python_version>='3.12'",
         "PyYAML; python_version<'3.12'",
-        "six",
     ],
     test_suite="test",
     tests_require=[

--- a/shopify/api_access.py
+++ b/shopify/api_access.py
@@ -2,13 +2,6 @@ import re
 import sys
 
 
-def basestring_type():
-    if sys.version_info[0] < 3:  # Backwards compatibility for python < v3.0.0
-        return basestring
-    else:
-        return str
-
-
 class ApiAccessError(Exception):
     pass
 
@@ -20,7 +13,7 @@ class ApiAccess:
     IMPLIED_SCOPE_RE = re.compile(r"\A(?P<unauthenticated>unauthenticated_)?write_(?P<resource>.*)\Z")
 
     def __init__(self, scopes):
-        if isinstance(scopes, basestring_type()):
+        if isinstance(scopes, str):
             scopes = scopes.split(self.SCOPE_DELIMITER)
 
         self.__store_scopes(scopes)

--- a/shopify/base.py
+++ b/shopify/base.py
@@ -5,8 +5,7 @@ import shopify.mixins as mixins
 import shopify
 import threading
 import sys
-from six.moves import urllib
-import six
+import urllib.parse
 
 from shopify.collection import PaginatedCollection
 from pyactiveresource.collection import Collection
@@ -152,8 +151,7 @@ class ShopifyResourceMeta(ResourceMeta):
     url = property(get_url, set_url, None, "Base URL including protocol and shopify domain")
 
 
-@six.add_metaclass(ShopifyResourceMeta)
-class ShopifyResource(ActiveResource, mixins.Countable):
+class ShopifyResource(ActiveResource, mixins.Countable, metaclass=ShopifyResourceMeta):
     _format = formats.JSONFormat
     _threadlocal = threading.local()
     _headers = {"User-Agent": "ShopifyPythonAPI/%s Python/%s" % (shopify.VERSION, sys.version.split(" ", 1)[0])}

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -1,7 +1,9 @@
+import json
+import urllib.error
+import urllib.request
+
 import shopify
 from ..base import ShopifyResource
-from six.moves import urllib
-import json
 
 
 class GraphQL:

--- a/shopify/resources/image.py
+++ b/shopify/resources/image.py
@@ -1,6 +1,6 @@
 from ..base import ShopifyResource
 from ..resources import Metafield
-from six.moves import urllib
+import urllib.parse
 import base64
 import re
 

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -1,6 +1,8 @@
 import time
 import hmac
 import json
+import urllib.parse
+import urllib.request
 from hashlib import sha256
 
 try:
@@ -9,10 +11,8 @@ except ImportError:
     import json
 import re
 from contextlib import contextmanager
-from six.moves import urllib
 from shopify.api_access import ApiAccess
 from shopify.api_version import ApiVersion, Release, Unstable
-import six
 
 
 class ValidationException(Exception):
@@ -28,7 +28,7 @@ class Session(object):
 
     @classmethod
     def setup(cls, **kwargs):
-        for k, v in six.iteritems(kwargs):
+        for k, v in kwargs.items():
             setattr(cls, k, v)
 
     @classmethod
@@ -165,7 +165,7 @@ class Session(object):
         """
 
         def encoded_pairs(params):
-            for k, v in six.iteritems(params):
+            for k, v in params.items():
                 if k == "hmac":
                     continue
 

--- a/shopify/session_token.py
+++ b/shopify/session_token.py
@@ -1,15 +1,9 @@
 import jwt
 import re
-import six
 import sys
+from urllib.parse import urljoin
 
 from shopify.utils import shop_url
-
-if sys.version_info[0] < 3:  # Backwards compatibility for python < v3.0.0
-    from urlparse import urljoin
-else:
-    from urllib.parse import urljoin
-
 
 ALGORITHM = "HS256"
 PREFIX = "Bearer "
@@ -61,7 +55,7 @@ def _decode_session_token(session_token, api_key, secret):
             options={"require": REQUIRED_FIELDS},
         )
     except jwt.exceptions.PyJWTError as exception:
-        six.raise_from(SessionTokenError(str(exception)), exception)
+        raise SessionTokenError(str(exception)) from exception
 
 
 def _validate_issuer(decoded_payload):

--- a/test/inventory_level_test.py
+++ b/test/inventory_level_test.py
@@ -1,6 +1,6 @@
 import shopify
 import json
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 from test.test_helper import TestCase
 
 

--- a/test/session_test.py
+++ b/test/session_test.py
@@ -3,8 +3,7 @@ from test.test_helper import TestCase
 import hmac
 from hashlib import sha256
 import time
-from six.moves import urllib
-from six import u
+import urllib.parse
 
 
 class SessionTest(TestCase):
@@ -182,7 +181,7 @@ class SessionTest(TestCase):
             "shop": "some-shop.myshopify.com",
             "code": "a94a110d86d2452eb3e2af4cfb8a3828",
             "timestamp": "1337178173",
-            "hmac": u("2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2"),
+            "hmac": "2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2",
         }
         self.assertTrue(shopify.Session.validate_hmac(params))
 
@@ -192,7 +191,7 @@ class SessionTest(TestCase):
         params = {
             "shop": "some-shop.myshopify.com",
             "code": "a94a110d86d2452eb3e2af4cfb8a3828",
-            "hmac": u("2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2"),
+            "hmac": "2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2",
         }
         self.assertFalse(shopify.Session.validate_params(params))
 
@@ -204,7 +203,7 @@ class SessionTest(TestCase):
                 2,
                 1,
             ],
-            "hmac": u("b93b9f82996f6f8bf9f1b7bbddec284c8fabacdc4e12dc80550b4705f3003b1e"),
+            "hmac": "b93b9f82996f6f8bf9f1b7bbddec284c8fabacdc4e12dc80550b4705f3003b1e",
         }
         self.assertEqual(True, shopify.Session.validate_hmac(params))
 


### PR DESCRIPTION
Hi,

shopifiy has enterred Debian today https://tracker.debian.org/pkg/python-shopifyapi :-)

... but we are slowly removing old Python2 compatibility layers, such as `six`
https://wiki.debian.org/Python3-six-removal

Please consider this PR.

The project metadata already state that Py2.7 support is dropped; that's why I spent the time to preprase this PR.