### PR TITLE
Fix: Upgrade pre-commit dependencies to resolve CI failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,15 +2,15 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.15.8
+    rev: v3.3.3
     hooks:
       - id: pylint

--- a/scripts/shopify_api.py
+++ b/scripts/shopify_api.py
@@ -128,7 +128,7 @@ class Tasks(object):
         if os.path.exists(filename):
             raise ConfigFileError("There is already a config file at " + filename)
         else:
-            config = dict(protocol="https")
+            config = {"protocol": "https"}
             domain = input("Domain? (leave blank for %s.myshopify.com) " % (connection))
             if not domain.strip():
                 domain = "%s.myshopify.com" % (connection)

--- a/shopify/api_access.py
+++ b/shopify/api_access.py
@@ -14,7 +14,6 @@ class ApiAccessError(Exception):
 
 
 class ApiAccess:
-
     SCOPE_DELIMITER = ","
     SCOPE_RE = re.compile(r"\A(?P<unauthenticated>unauthenticated_)?(write|read)_(?P<resource>.*)\Z")
     IMPLIED_SCOPE_RE = re.compile(r"\A(?P<unauthenticated>unauthenticated_)?write_(?P<resource>.*)\Z")

--- a/shopify/mixins.py
+++ b/shopify/mixins.py
@@ -24,7 +24,7 @@ class Metafields(object):
         if self.is_new():
             raise ValueError("You can only add metafields to a resource that has been saved")
 
-        metafield._prefix_options = dict(resource=self.__class__.plural, resource_id=self.id)
+        metafield._prefix_options = {"resource": self.__class__.plural, "resource_id": self.id}
         metafield.save()
         return metafield
 

--- a/shopify/session.py
+++ b/shopify/session.py
@@ -54,7 +54,7 @@ class Session(object):
         return
 
     def create_permission_url(self, scope, redirect_uri, state=None):
-        query_params = dict(client_id=self.api_key, scope=",".join(scope), redirect_uri=redirect_uri)
+        query_params = {"client_id": self.api_key, "scope": ",".join(scope), "redirect_uri": redirect_uri}
         if state:
             query_params["state"] = state
         return "https://%s/admin/oauth/authorize?%s" % (self.url, urllib.parse.urlencode(query_params))
@@ -69,7 +69,7 @@ class Session(object):
         code = params["code"]
 
         url = "https://%s/admin/oauth/access_token?" % self.url
-        query_params = dict(client_id=self.api_key, client_secret=self.secret, code=code)
+        query_params = {"client_id": self.api_key, "client_secret": self.secret, "code": code}
         request = urllib.request.Request(url, urllib.parse.urlencode(query_params).encode("utf-8"))
         response = urllib.request.urlopen(request)
 


### PR DESCRIPTION
Fix: Upgrade pre-commit dependencies to resolve CI failures

### WHY are these changes introduced?

Fixes #754 

Pre-commit checks are failing in GitHub Actions with the current dependencies. This is blocking other PRs like #752 and #753.

### WHAT is this pull request doing?

- Upgrades pre-commit dependencies to their latest versions:
  - pylint: v2.15.8 -> v3.3.3
  - black: 22.3.0 -> 24.10.0
  - pre-commit-hooks: v3.4.0 -> v5.0.0
- Fixes new pylint warnings introduced by the upgrade

If this approach isn't aligned with the project's direction, please let me know and I'll be happy to close this PR.

### Checklist

- [ ] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
