### PR TITLE
[Feature] Return dictionary and raise GraphQLException on error from GraphQL query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 == Unreleased
 
+- Return dictionary and raise GraphQLException on error from GraphQL query
 - Remove requirement to provide scopes to Permission URL, as it should be omitted if defined with the TOML file.
 
 == Version 12.7.0

--- a/shopify/resources/graphql.py
+++ b/shopify/resources/graphql.py
@@ -1,7 +1,15 @@
 import shopify
-from ..base import ShopifyResource
 from six.moves import urllib
 import json
+
+
+class GraphQLException(Exception):
+    def __init__(self, response):
+        self._response = response
+
+    @property
+    def errors(self):
+        return self._response['errors']
 
 
 class GraphQL:
@@ -16,7 +24,6 @@ class GraphQL:
         return merged_headers
 
     def execute(self, query, variables=None, operation_name=None):
-        endpoint = self.endpoint
         default_headers = {"Accept": "application/json", "Content-Type": "application/json"}
         headers = self.merge_headers(default_headers, self.headers)
         data = {"query": query, "variables": variables, "operationName": operation_name}
@@ -25,8 +32,9 @@ class GraphQL:
 
         try:
             response = urllib.request.urlopen(req)
-            return response.read().decode("utf-8")
+            result = json.loads(response.read().decode("utf-8"))
+            if result.get('errors'):
+                raise GraphQLException(result)
+            return result
         except urllib.error.HTTPError as e:
-            print((e.read()))
-            print("")
-            raise e
+            raise GraphQLException(json.load(e.fp))

--- a/test/graphql_test.py
+++ b/test/graphql_test.py
@@ -1,5 +1,4 @@
 import shopify
-import json
 from test.test_helper import TestCase
 
 
@@ -31,7 +30,7 @@ class GraphQLTest(TestCase):
             }
         """
         result = self.client.execute(query)
-        self.assertTrue(json.loads(result)["shop"]["name"] == "Apple Computers")
+        self.assertTrue(result["shop"]["name"] == "Apple Computers")
 
     def test_specify_operation_name(self):
         query = """
@@ -43,4 +42,4 @@ class GraphQLTest(TestCase):
             }
         """
         result = self.client.execute(query, operation_name="GetShop")
-        self.assertTrue(json.loads(result)["shop"]["name"] == "Apple Computers")
+        self.assertTrue(result["shop"]["name"] == "Apple Computers")


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Using the GraphQL API, the response are raw text containing the JSON.
The errors are most of the time answered with a 200 status with an `errors` array.

### WHAT is this pull request doing?

This ease the usage of GraphQL API by ensuring proper load of the JSON response and manage errors by raising an exception.

### Checklist

- [x] I have updated the CHANGELOG (if applicable)
- [x] I have followed the [Shopify Python](https://github.com/Shopify/shopify_python) guide
