### PR TITLE
No-op - Pinning github actions to commit SHAs

### DIFF
--- a/.github/workflows/api_update_reminder.yml
+++ b/.github/workflows/api_update_reminder.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2.4.0
+      - uses: JasonEtco/create-an-issue@e6b4b190af80961b6462c725454e7828d0247a68 # v2.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/api_update_reminder_on_release.yml
+++ b/.github/workflows/api_update_reminder_on_release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2.4.0
+      - uses: JasonEtco/create-an-issue@e6b4b190af80961b6462c725454e7828d0247a68 # v2.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Tests
         run: python -m pytest -v
       - name: upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
         with:
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/close-waiting-for-response-issues.yml
+++ b/.github/workflows/close-waiting-for-response-issues.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: close-issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,4 +14,4 @@ jobs:
     - name: Setup
       uses: actions/setup-python@v4
     - name: Pre-commit
-      uses: pre-commit/action@v2.0.0
+      uses: pre-commit/action@0764670bf370aab253130d534e1eda7ff497dc60 # v2.0.0

--- a/.github/workflows/remove-labels-on-activity.yml
+++ b/.github/workflows/remove-labels-on-activity.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1
         if: contains(github.event.issue.labels.*.name, 'Waiting for Response')
         with:
           labels: |


### PR DESCRIPTION
## Why?

By using `some-org/some-action@v3` you are trusting a mutable tag. If the upstream repo is compromised, a force-pushed `v3` ships malicious code into your workflow on the next run — see [tj-actions/changed-files (March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066) for recent real-world cases that leaked secrets across thousands of downstream workflows.

Pinning to a full 40-char SHA (`uses: tj-actions/changed-files@<sha> # v45.0.3`) makes the reference immutable and helps to mitigate this type of supply chain attacks.


cc @Shopify/dev_experience @byrichardpowell for review.