### PR TITLE
Deprecate in favor of shopifyapp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 == Unreleased
 
+- **Deprecated:** This package is no longer maintained. Use [`shopifyapp`](https://pypi.org/project/shopifyapp/) instead, which supports the latest Shopify platform features. The `Development Status` classifier is now `7 - Inactive`, the PyPI description and README carry a deprecation notice, and importing the package emits a `DeprecationWarning`. Existing users can keep using it, but no new features or security fixes are planned. See the [shopify-app-python README](https://github.com/Shopify/shopify-app-python#readme) to upgrade.
 - Remove requirement to provide scopes to Permission URL, as it should be omitted if defined with the TOML file.
 
 == Version 12.7.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-**Note:** We've released a new experimental package for Python. Please read [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325). The new Python package supports the latest Shopify platform features and we'd love your feedback. Please see [shopifyapp](https://pypi.org/project/shopifyapp/) to get started.
+> [!WARNING]
+> **This package is deprecated and no longer maintained.** Use [`shopifyapp`](https://pypi.org/project/shopifyapp/) instead. It supports the latest Shopify platform features. For background, see [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325).
 
 # Shopify API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> **This package is deprecated and no longer maintained.** Use [`shopifyapp`](https://pypi.org/project/shopifyapp/) instead. It supports the latest Shopify platform features. For background, see [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325).
+> **This package is deprecated and no longer maintained.** Use [`shopifyapp`](https://pypi.org/project/shopifyapp/) instead, which supports the latest Shopify platform features. It will keep working for existing users, but no new features or security fixes are planned. See the [`shopify-app-python` README](https://github.com/Shopify/shopify-app-python#readme) to upgrade. For background, see [rethinking our support for PHP & Python packages](https://community.shopify.dev/t/rethinking-support-for-php-python-packages/28325).
 
 # Shopify API
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     platforms="Any",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,13 @@ NAME = "ShopifyAPI"
 exec(open("shopify/version.py").read())
 DESCRIPTION = "Shopify API for Python"
 LONG_DESCRIPTION = """\
+DEPRECATED: This package is no longer maintained. Use the shopifyapp
+package (https://pypi.org/project/shopifyapp/) instead, which supports the
+latest Shopify platform features. See the shopify-app-python README for how
+to upgrade: https://github.com/Shopify/shopify-app-python#readme. This
+package will keep working for existing users but will not receive new
+features or security fixes.
+
 The ShopifyAPI library allows python developers to programmatically
 access the admin section of stores using an ActiveResource like
 interface similar the ruby Shopify API gem. The library makes HTTP

--- a/shopify/__init__.py
+++ b/shopify/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from shopify.version import VERSION
 from shopify.session import Session, ValidationException
 from shopify.resources import *
@@ -5,3 +7,10 @@ from shopify.limits import Limits
 from shopify.api_version import *
 from shopify.api_access import *
 from shopify.collection import PaginatedIterator
+
+warnings.warn(
+    "ShopifyAPI is deprecated and no longer maintained. Use the 'shopifyapp' "
+    "package instead: https://pypi.org/project/shopifyapp/",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## What

Marks this package as deprecated now that `shopifyapp` has reached v1.0 GA.

- Sets the `Development Status` classifier to `7 - Inactive` (PyPI's inactivity signal; PyPI has no Packagist-style abandoned pointer).
- Updates the README notice from "experimental package available" to a clear deprecation.

## Why

The new `shopifyapp` package supports the latest Shopify platform features and is now GA. This is the formal deprecation signal for the old library.

## Note

The classifier only appears on PyPI after a new release is published with this change.